### PR TITLE
Wrap app in React StrictMode

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,11 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-  import { createRoot } from "react-dom/client";
-  import App from "./App.tsx";
-  import "./index.css";
-
-  createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
   


### PR DESCRIPTION
## Summary
- Import StrictMode from React and wrap `<App />` in StrictMode when rendering via createRoot.

## Testing
- `npm run build`
- `npm run dev` (fails to open browser automatically but server started)


------
https://chatgpt.com/codex/tasks/task_e_68b929146170832e9d76657101e57997