### PR TITLE
refactor: use shared firebase instance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,14 +23,11 @@ import { FavoritesData, CustomSite, Website } from "./types";
 import "./App.css";
 
 // Firebase imports
-import { getAuth, onAuthStateChanged, User } from "firebase/auth";
-import { getFirestore, doc, getDoc, setDoc } from "firebase/firestore";
+import { onAuthStateChanged, User } from "firebase/auth";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { auth, db } from "./firebase";
 
-// Firebase auth와 firestore 인스턴스 초기화
-// firestore 인스턴스가 다른 곳에서 초기화되었을 경우 충돌을 막기 위해
-// 여기서는 주석 처리하거나, 적절한 방법으로 가져와야 합니다.
-// const auth = getAuth();
-// const db = getFirestore();
+// Firebase auth와 firestore 인스턴스는 firebase.ts에서 초기화됨
 
 export default function App() {
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
@@ -69,8 +66,6 @@ export default function App() {
 
   // 1. 로그인 상태 감지 및 데이터 동기화
   useEffect(() => {
-    const auth = getAuth();
-    const db = getFirestore();
     const unsubscribeAuth = onAuthStateChanged(auth, async (currentUser) => {
       setUser(currentUser);
       if (currentUser) {
@@ -107,7 +102,6 @@ export default function App() {
   // 2. 즐겨찾기 데이터 변경 시 Firestore에 저장
   useEffect(() => {
     if (user) {
-      const db = getFirestore();
       const userFavoritesRef = doc(db, "favorites", user.uid);
       setDoc(userFavoritesRef, favoritesData, { merge: true }).catch(e => {
         console.error("Failed to save favorites to Firestore:", e);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { getAuth, onAuthStateChanged, signOut, User } from "firebase/auth";
+import { onAuthStateChanged, signOut, User } from "firebase/auth";
+import { auth } from "../firebase";
 import { toast } from "sonner";
 import { logger } from "../lib/logger";
 
@@ -34,7 +35,6 @@ export function Header({
 
   useEffect(() => {
     if (!propsUser) {
-      const auth = getAuth();
       const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
         setLocalUser(currentUser);
       });
@@ -44,7 +44,6 @@ export function Header({
   }, [propsUser]);
 
   const handleLogout = async () => {
-    const auth = getAuth();
     try {
       await signOut(auth);
       logger.info("로그아웃 성공!");

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { getAuth, signInWithEmailAndPassword, signInWithPopup, GoogleAuthProvider } from "firebase/auth";
+import { signInWithEmailAndPassword, signInWithPopup } from "firebase/auth";
+import { auth, googleProvider } from "../firebase";
 import { logger } from "../lib/logger";
 
 interface LoginModalProps {
@@ -11,8 +12,6 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onClose, onSwitchToSignu
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-
-  const auth = getAuth();
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,9 +29,8 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onClose, onSwitchToSignu
 
   const handleGoogleLogin = async () => {
     setError('');
-    const provider = new GoogleAuthProvider();
     try {
-      await signInWithPopup(auth, provider);
+      await signInWithPopup(auth, googleProvider);
       logger.info('구글 로그인 성공!');
       onClose(); // 로그인 성공 시 모달 닫기
     } catch (error: any) {

--- a/src/components/SignupModal.tsx
+++ b/src/components/SignupModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { getAuth, createUserWithEmailAndPassword, signInWithPopup, GoogleAuthProvider } from "firebase/auth";
+import { createUserWithEmailAndPassword, signInWithPopup } from "firebase/auth";
+import { auth, googleProvider } from "../firebase";
 import { logger } from "../lib/logger";
 
 interface SignupModalProps {
@@ -11,8 +12,6 @@ export const SignupModal: React.FC<SignupModalProps> = ({ onClose, onSwitchToLog
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-
-  const auth = getAuth();
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,9 +29,8 @@ export const SignupModal: React.FC<SignupModalProps> = ({ onClose, onSwitchToLog
 
   const handleGoogleSignup = async () => {
     setError('');
-    const provider = new GoogleAuthProvider();
     try {
-      await signInWithPopup(auth, provider);
+      await signInWithPopup(auth, googleProvider);
       logger.info('구글 회원가입 및 로그인 성공!');
       onClose();
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- Use central firebase initialization for auth and Firestore
- Replace direct getAuth/getFirestore calls in components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b93026705c832e9cd3e2478d31460f