### PR TITLE
feat: add visit tracking utilities and preset

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Website } from "../types";
+import { trackVisit } from "../utils/visitTrack";
 
 interface WebsiteItemProps {
   website: Website;
@@ -79,6 +80,7 @@ export function WebsiteItem({
             onMouseLeave={(e) =>
               (e.currentTarget.style.color = "var(--main-dark)")
             }
+            onClick={() => trackVisit(website.id)}
           >
             {website.title}
           </a>

--- a/src/presets/architecture.ts
+++ b/src/presets/architecture.ts
@@ -1,0 +1,43 @@
+import { FavoritesData } from "../types";
+
+// 건축 샘플 즐겨찾기 프리셋
+export const ARCHITECTURE_STARTER: FavoritesData = {
+  items: ["archi-home", "archi-news"],
+  folders: [
+    { id: "design-ref", name: "디자인 레퍼런스", items: [] },
+    { id: "contest", name: "공모전", items: [] },
+    { id: "bim", name: "BIM/모델링", items: [] },
+    { id: "law", name: "법규/행정", items: [] },
+    { id: "tools", name: "툴/유틸리티", items: [] },
+  ],
+  widgets: [
+    {
+      id: "widget-weather",
+      type: "weather",
+      title: "날씨",
+      position: { x: 0, y: 0 },
+      size: { width: 2, height: 2 },
+    },
+    {
+      id: "widget-todo",
+      type: "todo",
+      title: "할 일",
+      position: { x: 2, y: 0 },
+      size: { width: 2, height: 2 },
+    },
+    {
+      id: "widget-dday",
+      type: "dday" as any,
+      title: "D-day",
+      position: { x: 4, y: 0 },
+      size: { width: 2, height: 2 },
+    },
+    {
+      id: "widget-news",
+      type: "news" as any,
+      title: "뉴스",
+      position: { x: 0, y: 2 },
+      size: { width: 4, height: 2 },
+    },
+  ],
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,7 +15,7 @@ export interface CategoryConfig {
 export type CategoryConfigMap = Record<string, CategoryConfig>;
 
 // 위젯 타입들
-export type WidgetType = 'weather' | 'clock' | 'memo' | 'todo' | 'calendar';
+export type WidgetType = 'weather' | 'clock' | 'memo' | 'todo' | 'calendar' | 'dday' | 'news';
 
 export interface Widget {
   id: string;
@@ -26,12 +26,15 @@ export interface Widget {
   size: { width: number; height: number };
 }
 
+export type SortMode = 'manual' | 'alpha' | 'freq';
+
 // 폴더 타입
 export interface FavoriteFolder {
   id: string;
   name: string;
   items: string[]; // website ids
   color?: string;
+  sortMode?: SortMode;
 }
 
 // 즐겨찾기 구조 확장
@@ -39,6 +42,7 @@ export interface FavoritesData {
   items: string[];
   folders: FavoriteFolder[];
   widgets: Widget[];
+  itemsSortMode?: SortMode;
 }
 
 // 사용자 추가 사이트

--- a/src/utils/applyPreset.ts
+++ b/src/utils/applyPreset.ts
@@ -1,0 +1,39 @@
+import { FavoritesData, FavoriteFolder, Widget } from "../types";
+
+function mergeIds(a: string[] = [], b: string[] = []): string[] {
+  return Array.from(new Set([...(a || []), ...(b || [])]));
+}
+
+function mergeFolders(a: FavoriteFolder[] = [], b: FavoriteFolder[] = []): FavoriteFolder[] {
+  const map = new Map<string, FavoriteFolder>();
+  a.forEach((f) => map.set(f.id, { ...f }));
+  b.forEach((f) => {
+    if (map.has(f.id)) {
+      const cur = map.get(f.id)!;
+      cur.items = mergeIds(cur.items, f.items);
+    } else {
+      map.set(f.id, { ...f });
+    }
+  });
+  return Array.from(map.values());
+}
+
+function mergeWidgets(a: Widget[] = [], b: Widget[] = []): Widget[] {
+  const map = new Map<string, Widget>();
+  a.forEach((w) => map.set(w.id, { ...w }));
+  b.forEach((w) => {
+    if (!map.has(w.id)) {
+      map.set(w.id, { ...w });
+    }
+  });
+  return Array.from(map.values());
+}
+
+export function applyPreset(current: FavoritesData, preset: FavoritesData): FavoritesData {
+  return {
+    items: mergeIds(current.items, preset.items),
+    folders: mergeFolders(current.folders, preset.folders),
+    widgets: mergeWidgets(current.widgets, preset.widgets),
+    itemsSortMode: current.itemsSortMode,
+  };
+}

--- a/src/utils/sorters.ts
+++ b/src/utils/sorters.ts
@@ -1,0 +1,18 @@
+import { SortMode } from "../types";
+
+export function sortByMode(
+  ids: string[],
+  mode: SortMode = "manual",
+  freqMap: Record<string, number> = {},
+  titleMap: Record<string, string> = {}
+): string[] {
+  if (mode === "alpha") {
+    return [...ids].sort((a, b) =>
+      (titleMap[a] || "").localeCompare(titleMap[b] || "")
+    );
+  }
+  if (mode === "freq") {
+    return [...ids].sort((a, b) => (freqMap[b] || 0) - (freqMap[a] || 0));
+  }
+  return ids;
+}

--- a/src/utils/visitTrack.ts
+++ b/src/utils/visitTrack.ts
@@ -1,0 +1,35 @@
+const KEY = "urwebs-visits-v1";
+const DAY = 24 * 60 * 60 * 1000;
+
+export function trackVisit(id: string) {
+  try {
+    const raw = localStorage.getItem(KEY);
+    const data: Record<string, number[]> = raw ? JSON.parse(raw) : {};
+    const arr = Array.isArray(data[id]) ? data[id] : [];
+    arr.push(Date.now());
+    data[id] = arr;
+    localStorage.setItem(KEY, JSON.stringify(data));
+  } catch (e) {
+    console.error("trackVisit failed", e);
+  }
+}
+
+export function buildFrequencyMap(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return {};
+    const data: Record<string, number[]> = JSON.parse(raw);
+    const cutoff = Date.now() - 30 * DAY;
+    const map: Record<string, number> = {};
+    Object.entries(data).forEach(([id, times]) => {
+      const score = (times || [])
+        .filter((t) => t >= cutoff)
+        .reduce((sum, t) => sum + (1 - (Date.now() - t) / (30 * DAY)), 0);
+      if (score > 0) map[id] = score;
+    });
+    return map;
+  } catch (e) {
+    console.error("buildFrequencyMap failed", e);
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary
- add architecture starter preset and preset merge utility
- implement visit tracking and sorting helpers
- track website visits on click
- extend types for sorting modes and widgets

## Testing
- `npm run build` *(fails: vite Permission denied)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b956a0b248832ea17c84ecbb67267e