### PR TITLE
feat: track visits and add sorting options

### DIFF
--- a/src/utils/sorters.ts
+++ b/src/utils/sorters.ts
@@ -1,14 +1,15 @@
-import { SortMode } from "../types";
+// src/utils/sorters.ts
+export type SortMode = "manual" | "alpha" | "freq";
 
 export function sortByMode(
   ids: string[],
-  mode: SortMode = "manual",
+  mode: SortMode,
   freqMap: Record<string, number> = {},
   titleMap: Record<string, string> = {}
 ): string[] {
   if (mode === "alpha") {
     return [...ids].sort((a, b) =>
-      (titleMap[a] || "").localeCompare(titleMap[b] || "")
+      (titleMap[a] || "").localeCompare(titleMap[b] || "", "ko")
     );
   }
   if (mode === "freq") {
@@ -16,3 +17,4 @@ export function sortByMode(
   }
   return ids;
 }
+

--- a/src/utils/visitTrack.ts
+++ b/src/utils/visitTrack.ts
@@ -1,35 +1,43 @@
-const KEY = "urwebs-visits-v1";
-const DAY = 24 * 60 * 60 * 1000;
+// src/utils/visitTrack.ts
+export const LS_VISITS = "urwebs-visits-v1";
+const THIRTY = 30 * 24 * 60 * 60 * 1000;
 
-export function trackVisit(id: string) {
+export function trackVisit(id: string): void {
   try {
-    const raw = localStorage.getItem(KEY);
+    const raw = localStorage.getItem(LS_VISITS);
     const data: Record<string, number[]> = raw ? JSON.parse(raw) : {};
     const arr = Array.isArray(data[id]) ? data[id] : [];
     arr.push(Date.now());
+    if (arr.length > 200) arr.splice(0, arr.length - 200);
     data[id] = arr;
-    localStorage.setItem(KEY, JSON.stringify(data));
+    localStorage.setItem(LS_VISITS, JSON.stringify(data));
   } catch (e) {
-    console.error("trackVisit failed", e);
+    console.warn("trackVisit failed", e);
   }
 }
 
 export function buildFrequencyMap(): Record<string, number> {
   try {
-    const raw = localStorage.getItem(KEY);
+    const raw = localStorage.getItem(LS_VISITS);
     if (!raw) return {};
     const data: Record<string, number[]> = JSON.parse(raw);
-    const cutoff = Date.now() - 30 * DAY;
+    const now = Date.now();
     const map: Record<string, number> = {};
     Object.entries(data).forEach(([id, times]) => {
-      const score = (times || [])
-        .filter((t) => t >= cutoff)
-        .reduce((sum, t) => sum + (1 - (Date.now() - t) / (30 * DAY)), 0);
+      if (!Array.isArray(times)) return;
+      const score = times
+        .filter((t) => now - t <= THIRTY)
+        .reduce((sum, t) => {
+          const age = now - t;
+          const w = 1 - age / THIRTY;
+          return sum + (0.5 + 0.5 * w);
+        }, 0);
       if (score > 0) map[id] = score;
     });
     return map;
   } catch (e) {
-    console.error("buildFrequencyMap failed", e);
+    console.warn("buildFrequencyMap failed", e);
     return {};
   }
 }
+


### PR DESCRIPTION
## Summary
- track website visits in localStorage and compute frequency scores
- support manual, alphabetical, and frequency-based sorting
- allow choosing sort mode for root favorites and folders

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab321a934832e918fca30c89eaef9