### PR TITLE
feat: add personal and global top lists sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { AdBanner } from "./components/AdBanner";
 import { AddWebsiteModal } from "./components/AddWebsiteModal";
 import { StartPage } from "./components/StartPage";
 import { MidBanner } from "./components/MidBanner";
+import { TopList } from "./components/TopList";
 
 import { websites, categoryConfig, categoryOrder } from "./data/websites";
 import { FavoritesData, CustomSite, Website } from "./types";
@@ -202,6 +203,12 @@ export default function App() {
     }
 
     setFavoritesData(newData);
+  };
+
+  const handleAddFav = (id: string) => {
+    setFavoritesData((prev) =>
+      applyPreset(prev, { items: [id], folders: [], widgets: [] })
+    );
   };
 
   const addCustomSite = (site: CustomSite, selectedFolderId: string) => {
@@ -437,9 +444,12 @@ export default function App() {
               ))}
             </div>
 
-            <div className="w-24 flex flex-col gap-4 sm:hidden">
-              <AdBanner text="광고3" />
-              <AdBanner text="광고4" />
+            {/* // [TopList] */}
+            <div className="w-64 hidden xl:block">
+              <div className="sticky top-6 space-y-4">
+                <TopList mode="mine" onAddFavorite={handleAddFav} />
+                <TopList mode="global" onAddFavorite={handleAddFav} />
+              </div>
             </div>
           </div>
 

--- a/src/components/TopList.tsx
+++ b/src/components/TopList.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { websites, Website } from "../data/websites";
+import * as visitTrack from "../utils/visitTrack";
+
+const GLOBAL_TOP20: string[] = [
+  "60",
+  "1",
+  "2",
+  "3",
+  "5",
+  "65",
+  "71",
+  "KR-D-001",
+  "KR-D-002",
+  "KR-D-003",
+  "KR-D-004",
+  "KR-D-006",
+  "KR-D-007",
+  "KR-D-009",
+  "KR-D-010",
+  "62",
+  "63",
+  "145",
+  "KR-C-001",
+  "61",
+];
+
+interface TopListProps {
+  mode: "mine" | "global";
+  onAddFavorite: (id: string) => void;
+}
+
+const safeBuildFrequencyMap: () => Record<string, number> =
+  typeof visitTrack.buildFrequencyMap === "function"
+    ? visitTrack.buildFrequencyMap
+    : () => ({});
+
+export function TopList({ mode, onAddFavorite }: TopListProps) {
+  const frequencyMap = React.useMemo(() => {
+    if (mode !== "mine") return {};
+    return safeBuildFrequencyMap();
+  }, [mode]);
+
+  const ids = React.useMemo(() => {
+    if (mode === "mine") {
+      return Object.entries(frequencyMap)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 10)
+        .map(([id]) => id);
+    }
+    return GLOBAL_TOP20;
+  }, [mode, frequencyMap]);
+
+  const items = React.useMemo(() => {
+    return ids
+      .map((id) => websites.find((w) => w.id === id))
+      .filter((w): w is Website => Boolean(w));
+  }, [ids]);
+
+  const title = mode === "mine" ? "내 TOP 10" : "전체 TOP 20";
+
+  if (items.length === 0) {
+    return (
+      <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded">
+        <h2 className="font-bold mb-2 text-gray-800 dark:text-gray-100">{title}</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          최근 방문 데이터가 부족합니다.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded">
+      <h2 className="font-bold mb-2 text-gray-800 dark:text-gray-100">{title}</h2>
+      <ul className="space-y-2">
+        {items.map((site) => (
+          <li key={site.id} className="flex items-center gap-2">
+            <img
+              src={`https://www.google.com/s2/favicons?domain=${site.url}&sz=16`}
+              alt=""
+              className="w-4 h-4 flex-shrink-0"
+              onError={(e) => {
+                (e.target as HTMLImageElement).src =
+                  'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><rect width="16" height="16" fill="%23e5e7eb"/></svg>';
+              }}
+            />
+            <a
+              href={site.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-gray-800 dark:text-gray-200 hover:underline"
+            >
+              {site.title}
+            </a>
+            <button
+              type="button"
+              onClick={() => onAddFavorite(site.id)}
+              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              aria-label={`${site.title} 즐겨찾기 추가`}
+            >
+              [+ 즐겨찾기]
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default TopList;


### PR DESCRIPTION
## Summary
- add `TopList` component to show personal Top 10 from visit history and a mocked global Top 20
- integrate TopList sidebar in home layout and allow adding sites to favorites without duplicates

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab900571c832e954e5e6ad5e0dba7