### PR TITLE
feat: onboarding flow and recommendation tray

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { onAuthStateChanged, signOut } from "firebase/auth";
 import { doc, getDoc, setDoc } from "firebase/firestore";
 
 import { Header } from "./components/Header";
-import { UserGuide } from "./components/UserGuide";
 import { LoginModal } from "./components/LoginModal";
 import { SignupModal } from "./components/SignupModal";
 // (삭제) import { GoogleAuthModal } from "./components/GoogleAuthModal";
@@ -19,6 +18,8 @@ import { AdBanner } from "./components/AdBanner";
 import { AddWebsiteModal } from "./components/AddWebsiteModal";
 import { StartPage } from "./components/StartPage";
 import { MidBanner } from "./components/MidBanner";
+import { Onboarding } from "./components/Onboarding";
+import { RecommendTray } from "./components/RecommendTray";
 import { TopList } from "./components/TopList";
 
 import { websites, categoryConfig, categoryOrder } from "./data/websites";
@@ -33,10 +34,10 @@ import { ARCHITECTURE_STARTER } from "./presets/architecture";
 // urwebs 키 세팅
 // ---------------------------
 const LS_KEYS = {
-  GUIDE: "urwebs-guide-seen",
   MODE: "urwebs-mode",
   FAV: "urwebs-favorites-v3",
   CUSTOM: "urwebs-custom-sites",
+  ONBOARD: "urwebs-onboarding-v1",
 };
 
 export default function App() {
@@ -62,10 +63,9 @@ export default function App() {
   const [isContactModalOpen, setIsContactModalOpen] = useState(false);
   const [isAddSiteModalOpen, setIsAddSiteModalOpen] = useState(false);
 
-  // 유저 가이드 노출 여부
-  const [showUserGuide, setShowUserGuide] = useState(() => {
-    const hasSeenGuide = localStorage.getItem(LS_KEYS.GUIDE);
-    return !hasSeenGuide;
+  // 온보딩 노출 여부
+  const [showOnboarding, setShowOnboarding] = useState(() => {
+    return !localStorage.getItem(LS_KEYS.ONBOARD);
   });
 
   // 뷰
@@ -311,16 +311,6 @@ export default function App() {
         onLogout={handleLogout}
       />
 
-      {/* 유저 가이드 모달 */}
-      {showUserGuide && (
-        <UserGuide
-          onClose={() => {
-            setShowUserGuide(false);
-            localStorage.setItem(LS_KEYS.GUIDE, "true");
-          }}
-        />
-      )}
-
       {/* 로그인/회원가입 모달 */}
       {isLoginModalOpen && (
         <LoginModal
@@ -364,6 +354,23 @@ export default function App() {
           }}
         >
           <FloatingContact onContactClick={() => setIsContactModalOpen(true)} />
+          {/* // [Onboarding] */}
+          {showOnboarding && (
+            <Onboarding
+              onApplyPreset={() =>
+                setFavoritesData(
+                  applyPreset(favoritesData, ARCHITECTURE_STARTER)
+                )
+              }
+              onOpenAddSite={() =>
+                window.dispatchEvent(new CustomEvent('openAddSiteModal'))
+              }
+              onOpenHomepageGuide={() =>
+                alert('브라우저 설정에서 시작페이지를 urwebs로 설정하세요.')
+              }
+              onClose={() => setShowOnboarding(false)}
+            />
+          )}
           {/* // [MidBanner] */}
           <MidBanner
             onApplyPreset={() =>
@@ -377,11 +384,18 @@ export default function App() {
             }
           />
 
+          {/* // [RecommendTray] */}
+          <RecommendTray
+            onApplyPreset={(preset) =>
+              setFavoritesData(applyPreset(favoritesData, preset))
+            }
+          />
+
           <FavoritesSectionNew
             favoritesData={favoritesData}
             onUpdateFavorites={setFavoritesData}
             showSampleImage={showSampleImage}
-            onShowGuide={() => setShowUserGuide(true)}
+            onShowGuide={() => setShowOnboarding(true)}
             onSaveData={() => {
               alert("설정이 저장되었습니다!");
             }}

--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -679,6 +679,7 @@ export function FavoritesSectionNew({
             }}
             className="bg-green-500 hover:bg-green-600 text-white px-2 py-1 rounded text-xs transition-colors flex items-center gap-1"
             type="button"
+            aria-label="사이트 추가"
           >
             + 사이트 추가
           </button>

--- a/src/components/MidBanner.tsx
+++ b/src/components/MidBanner.tsx
@@ -44,7 +44,7 @@ export function MidBanner({
             className="px-3 py-1 rounded border text-xs bg-white dark:bg-gray-800"
             style={{ borderColor: "var(--border-urwebs)" }}
             onClick={onOpenAddSite}
-            aria-label="직접 추가"
+            aria-label="사이트 직접 추가"
             type="button"
           >
             직접 추가

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+
+interface OnboardingProps {
+  onApplyPreset: () => void;
+  onOpenAddSite: () => void;
+  onOpenHomepageGuide: () => void;
+  onClose?: () => void;
+}
+
+export function Onboarding({
+  onApplyPreset,
+  onOpenAddSite,
+  onOpenHomepageGuide,
+  onClose,
+}: OnboardingProps) {
+  const [step, setStep] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  const steps = [
+    {
+      title: '샘플 즐겨찾기 담기',
+      description: '건축 스타터팩을 한 번에 담아보세요.',
+      action: onApplyPreset,
+      actionLabel: '샘플 담기',
+    },
+    {
+      title: '사이트 직접 추가',
+      description: '원하는 사이트를 자유롭게 추가해보세요.',
+      action: onOpenAddSite,
+      actionLabel: '사이트 추가',
+    },
+    {
+      title: '시작페이지 설정',
+      description: '자주 쓰는 페이지를 시작페이지로 지정해보세요.',
+      action: onOpenHomepageGuide,
+      actionLabel: '시작페이지 안내',
+    },
+  ];
+
+  const close = () => {
+    localStorage.setItem('urwebs-onboarding-v1', 'done');
+    setVisible(false);
+    onClose && onClose();
+  };
+
+  const handleNext = () => {
+    if (step < steps.length - 1) {
+      setStep((s) => s + 1);
+    } else {
+      close();
+    }
+  };
+
+  const handlePrev = () => {
+    if (step > 0) setStep((s) => s - 1);
+  };
+
+  const handleSkip = () => {
+    close();
+  };
+
+  if (!visible) return null;
+
+  const current = steps[step];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      aria-label="온보딩"
+    >
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg max-w-sm w-full">
+        <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">
+          {current.title}
+        </h2>
+        <p className="text-sm mb-4 text-gray-700 dark:text-gray-200">
+          {current.description}
+        </p>
+
+        <div className="mb-4">
+          <button
+            onClick={current.action}
+            className="px-3 py-1 bg-[var(--main-point)] text-white text-xs rounded"
+            type="button"
+            aria-label={current.actionLabel}
+          >
+            {current.actionLabel}
+          </button>
+        </div>
+
+        <div className="flex justify-between items-center">
+          <button
+            onClick={handlePrev}
+            disabled={step === 0}
+            className="px-2 py-1 text-xs rounded border disabled:opacity-50"
+            style={{ borderColor: 'var(--border-urwebs)' }}
+            aria-label="이전"
+            type="button"
+          >
+            이전
+          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={handleSkip}
+              className="px-2 py-1 text-xs rounded border"
+              style={{ borderColor: 'var(--border-urwebs)' }}
+              aria-label="스킵"
+              type="button"
+            >
+              스킵
+            </button>
+            <button
+              onClick={handleNext}
+              className="px-2 py-1 text-xs rounded bg-[var(--main-point)] text-white"
+              aria-label={step === steps.length - 1 ? '완료' : '다음'}
+              type="button"
+            >
+              {step === steps.length - 1 ? '완료' : '다음'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Onboarding;
+

--- a/src/components/RecommendTray.tsx
+++ b/src/components/RecommendTray.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { FavoritesData } from '../types';
+
+interface RecommendTrayProps {
+  onApplyPreset: (preset: FavoritesData) => void;
+}
+
+const RECOMMENDATIONS: { title: string; preset: FavoritesData }[] = [
+  { title: '건축 인기', preset: { items: ['1', '2', '3'], folders: [], widgets: [] } },
+  { title: '급상승', preset: { items: ['5', '60', '63'], folders: [], widgets: [] } },
+  { title: '자주 같이 담는 사이트', preset: { items: ['12', '13', '14'], folders: [], widgets: [] } },
+  { title: '건축가 모음', preset: { items: ['101', '105', '108'], folders: [], widgets: [] } },
+  { title: '포털 모음', preset: { items: ['301', '302', '303'], folders: [], widgets: [] } },
+  { title: '자료 모음', preset: { items: ['KR-R-001', 'KR-R-002', 'KR-R-003'], folders: [], widgets: [] } },
+];
+
+export function RecommendTray({ onApplyPreset }: RecommendTrayProps) {
+  return (
+    <div className="max-w-screen-2xl mx-auto px-5 sm:px-2 mb-6">
+      <div className="grid gap-4 grid-cols-3 sm:grid-cols-2">
+        {RECOMMENDATIONS.map((rec) => (
+          <div
+            key={rec.title}
+            className="p-3 border rounded bg-white dark:bg-gray-800"
+            style={{ borderColor: 'var(--border-urwebs)' }}
+          >
+            <h3 className="text-sm font-medium mb-2 text-gray-800 dark:text-gray-100">
+              {rec.title}
+            </h3>
+            <button
+              onClick={() => onApplyPreset(rec.preset)}
+              className="px-2 py-1 text-xs rounded bg-[var(--main-point)] text-white"
+              aria-label={`${rec.title} 담기`}
+              type="button"
+            >
+              담기
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default RecommendTray;
+


### PR DESCRIPTION
## Summary
- add 3-step onboarding modal with preset, site add and homepage guide actions
- enhance favorites section and MidBanner buttons for adding sites
- introduce static recommendation tray for quick preset additions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68babde0f80c832e9542b4559142b335