### PR TITLE
Add static metadata, robots.txt, and status build script

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,15 @@
     <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>urwebs</title>
+      <title>UrWebs — 하루를 시작하는 시작페이지</title>
+      <meta name="description" content="즐겨찾기·폴더·위젯을 한 번에. 분야별 샘플로 바로 시작하세요." />
+      <meta property="og:title" content="UrWebs" />
+      <meta property="og:description" content="즐겨찾기·폴더·위젯을 한 번에." />
+      <meta property="og:url" content="https://urwebs.vercel.app/" />
+      <meta property="og:image" content="/og/og-home.png" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="theme-color" content="#8b5cf6" />
+      <link rel="icon" href="/favicon.ico" />
     </head>
 
     <body>

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
             "vitest": "^1.0.0"
       },
       "scripts": {
+            "prebuild": "node scripts/write-status.mjs",
             "dev": "vite",
             "build": "vite build",
             "test": "vitest run"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://urwebs.com/sitemap.xml

--- a/scripts/write-status.mjs
+++ b/scripts/write-status.mjs
@@ -1,0 +1,12 @@
+import { writeFileSync } from "fs";
+import { execSync } from "child_process";
+const sha = execSync("git rev-parse --short HEAD").toString().trim();
+const msg = execSync('git log -1 --pretty=%s').toString().trim();
+const now = new Date().toISOString();
+writeFileSync("public/status.txt",
+`ok
+app: urwebs
+version: ${sha}
+buildTime: ${now}
+commit: ${msg}
+`);

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,16 @@
 {
   "headers": [
     {
-      "source": "/__status",
+      "source": "/status.txt",
       "headers": [
         { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
         { "key": "Cache-Control", "value": "no-store" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(js|css)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- enrich index.html with basic description, Open Graph and Twitter tags, favicon link, and theme color for better previews
- add robots.txt allowing all bots and linking to sitemap
- configure Vercel headers for `status.txt` and immutable JS/CSS caching
- add prebuild script that records commit info and timestamp into `public/status.txt`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad9f8eafc832e98fad5861b2ec9c0