### PR TITLE
feat: redesign board layout with view counts

### DIFF
--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -1,18 +1,27 @@
 import { Link } from "react-router-dom";
 import { Post } from "../libs/posts.repo";
 
-export default function PostItem({ post }: { post: Post }) {
+interface Props {
+  post: Post;
+  index: number;
+}
+
+export default function PostItem({ post, index }: Props) {
+  const date = post.createdAt?.toDate
+    ? post.createdAt.toDate()
+    : new Date(post.createdAt);
   return (
-    <div className="border-b p-2">
-      <Link to={`/post/${post.id}`} className="flex justify-between">
-        <div>
-          {post.pinned && <span className="text-red-500 mr-1">[공지]</span>}
-          <span>{post.title}</span>
-        </div>
-        <div className="text-sm text-gray-500">
-          {post.authorName}
-        </div>
-      </Link>
-    </div>
+    <tr className="border-b text-center">
+      <td className="py-2">{post.pinned ? "공지" : index}</td>
+      <td className="text-left">
+        {post.pinned && <span className="text-red-500 mr-1">[공지]</span>}
+        <Link to={`/post/${post.id}`} className="hover:underline">
+          {post.title}
+        </Link>
+      </td>
+      <td>{post.authorName}</td>
+      <td>{date.toLocaleDateString()}</td>
+      <td>{post.views ?? 0}</td>
+    </tr>
   );
 }

--- a/src/libs/posts.repo.ts
+++ b/src/libs/posts.repo.ts
@@ -12,6 +12,7 @@ import {
   where,
   updateDoc,
   serverTimestamp,
+  increment,
 } from "firebase/firestore";
 import { db } from "../firebase";
 
@@ -23,6 +24,7 @@ export interface Post {
   authorUid: string;
   authorName: string;
   pinned: boolean;
+  views: number;
   createdAt: any;
   updatedAt: any;
 }
@@ -64,9 +66,12 @@ export async function getPost(id: string) {
   return snap.exists() ? ({ id: snap.id, ...(snap.data() as any) } as Post) : null;
 }
 
-export async function createPost(data: Omit<Post, "id" | "createdAt" | "updatedAt">) {
+export async function createPost(
+  data: Omit<Post, "id" | "createdAt" | "updatedAt" | "views">
+) {
   const docRef = await addDoc(collection(db, "posts"), {
     ...data,
+    views: 0,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   });
@@ -85,4 +90,8 @@ export async function updatePost(
 
 export async function deletePost(id: string) {
   await deleteDoc(doc(db, "posts", id));
+}
+
+export async function increaseView(id: string) {
+  await updateDoc(doc(db, "posts", id), { views: increment(1) });
 }

--- a/src/pages/BoardList.tsx
+++ b/src/pages/BoardList.tsx
@@ -69,21 +69,32 @@ export default function BoardList({ board }: Props) {
         onLogout={handleLogout}
         canWrite={canWrite}
       />
-      <div>
-        {posts.map((p) => (
-          <PostItem key={p.id} post={p} />
-        ))}
-        {lastDoc && (
-          <div className="text-center my-4">
-            <button
-              className="px-3 py-1 border"
-              onClick={() => load(false)}
-            >
-              더보기
-            </button>
-          </div>
-        )}
-      </div>
+      <table className="w-full table-fixed">
+        <thead>
+          <tr className="border-b text-center">
+            <th className="w-12">번호</th>
+            <th className="text-left">제목</th>
+            <th className="w-24">작성자</th>
+            <th className="w-32">날짜</th>
+            <th className="w-16">조회</th>
+          </tr>
+        </thead>
+        <tbody>
+          {posts.map((p, i) => (
+            <PostItem key={p.id} post={p} index={posts.length - i} />
+          ))}
+        </tbody>
+      </table>
+      {lastDoc && (
+        <div className="text-center my-4">
+          <button
+            className="px-3 py-1 border"
+            onClick={() => load(false)}
+          >
+            더보기
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { User, onAuthStateChanged } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 import { auth, db } from "../firebase";
-import { getPost, deletePost, Post } from "../libs/posts.repo";
+import { getPost, deletePost, Post, increaseView } from "../libs/posts.repo";
 
 export default function PostDetail() {
   const { id } = useParams();
@@ -14,7 +14,12 @@ export default function PostDetail() {
 
   useEffect(() => {
     if (id) {
-      getPost(id).then(setPost);
+      getPost(id).then((p) => {
+        if (p) {
+          setPost({ ...p, views: (p.views || 0) + 1 });
+          increaseView(p.id);
+        }
+      });
     }
   }, [id]);
 
@@ -44,11 +49,18 @@ export default function PostDetail() {
 
   if (!post) return <div className="p-4">Loading...</div>;
 
+  const createdAt = post.createdAt?.toDate
+    ? post.createdAt.toDate()
+    : new Date(post.createdAt);
+
   return (
     <div className="max-w-2xl mx-auto p-4">
       <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
-      <div className="text-sm text-gray-500 mb-4">
-        {post.authorName}
+      <div className="text-sm text-gray-500 mb-4 flex justify-between">
+        <span>{post.authorName}</span>
+        <span>
+          {createdAt.toLocaleDateString()} | 조회 {post.views ?? 0}
+        </span>
       </div>
       <div className="whitespace-pre-wrap mb-4">{post.content}</div>
       {(isOwner || isAdmin) && (


### PR DESCRIPTION
## Summary
- restructure board list into table layout
- track post views and display counts
- show author, date, and views on post detail and list

## Testing
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68bafdcc572c832eac9407ed5cdf6337