### PR TITLE
feat: enhance board layout

### DIFF
--- a/src/components/BoardLayout.tsx
+++ b/src/components/BoardLayout.tsx
@@ -13,7 +13,7 @@ export default function BoardLayout({ board, canWrite, children }: BoardLayoutPr
   return (
     <div className="max-w-2xl mx-auto">
       <header className="flex justify-between items-center p-4 border-b">
-        <h1 className="text-xl font-bold">{title}</h1>
+        <h1 className="text-2xl font-bold">{title}</h1>
         {canWrite && (
           <button
             onClick={() => navigate(`/write?board=${board}`)}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -10,7 +10,7 @@ export default function PostCard({ post, index }: Props) {
   const date = post.createdAt?.toDate
     ? post.createdAt.toDate()
     : new Date(post.createdAt);
-  const isNotice = post.board === "notice" || post.pinned;
+  const isNotice = post.pinned;
   return (
     <div className="border-b py-3">
       <Link to={`/post/${post.id}`} className="font-medium block truncate">
@@ -18,7 +18,7 @@ export default function PostCard({ post, index }: Props) {
         {post.title}
       </Link>
       <div className="text-xs text-gray-500 mt-1 flex gap-2">
-        <span>#{index}</span>
+        <span>{isNotice ? "공지" : `#${index}`}</span>
         <span>{post.authorName}</span>
         <span>{date.toLocaleDateString()}</span>
         <span>조회 {post.views ?? 0}</span>

--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -10,10 +10,10 @@ export default function PostItem({ post, index }: Props) {
   const date = post.createdAt?.toDate
     ? post.createdAt.toDate()
     : new Date(post.createdAt);
-  const isNotice = post.board === "notice" || post.pinned;
+  const isNotice = post.pinned;
   return (
     <tr className="border-b text-center">
-      <td className="py-2">{index}</td>
+      <td className="py-2">{isNotice ? "공지" : index}</td>
       <td className="text-left">
         {isNotice && <span className="text-red-500 mr-1">[공지]</span>}
         <Link to={`/post/${post.id}`} className="hover:underline block truncate">


### PR DESCRIPTION
## Summary
- highlight pinned posts with [공지] tag and special numbering
- enlarge board header title for clearer layout

## Testing
- `npm test` (fails: vitest: not found)
- `npm install vitest` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68bb07bba758832ea5971e2efd4f0ad7