### PR TITLE
feat: redesign board pages for notices and free posts

### DIFF
--- a/src/components/BoardLayout.tsx
+++ b/src/components/BoardLayout.tsx
@@ -11,13 +11,13 @@ export default function BoardLayout({ board, canWrite, children }: BoardLayoutPr
   const navigate = useNavigate();
   const title = board === "notice" ? "공지사항" : "자유게시판";
   return (
-    <div className="max-w-2xl mx-auto">
-      <header className="flex justify-between items-center p-4 border-b">
-        <h1 className="text-2xl font-bold">{title}</h1>
+    <div className="max-w-4xl mx-auto">
+      <header className="flex items-center justify-between p-6 border-b">
+        <h1 className="text-3xl font-bold">{title}</h1>
         {canWrite && (
           <button
             onClick={() => navigate(`/write?board=${board}`)}
-            className="px-3 py-1 bg-blue-500 text-white rounded"
+            className="px-4 py-2 bg-blue-500 text-white rounded"
           >
             글쓰기
           </button>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -12,12 +12,12 @@ export default function PostCard({ post, index }: Props) {
     : new Date(post.createdAt);
   const isNotice = post.pinned;
   return (
-    <div className="border-b py-3">
-      <Link to={`/post/${post.id}`} className="font-medium block truncate">
+    <div className="border rounded p-4 mb-2">
+      <Link to={`/post/${post.id}`} className="block truncate text-lg font-semibold">
         {isNotice && <span className="text-red-500 mr-1">[공지]</span>}
         {post.title}
       </Link>
-      <div className="text-xs text-gray-500 mt-1 flex gap-2">
+      <div className="mt-1 text-sm text-gray-500 flex flex-wrap gap-2">
         <span>{isNotice ? "공지" : `#${index}`}</span>
         <span>{post.authorName}</span>
         <span>{date.toLocaleDateString()}</span>

--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -12,11 +12,11 @@ export default function PostItem({ post, index }: Props) {
     : new Date(post.createdAt);
   const isNotice = post.pinned;
   return (
-    <tr className="border-b text-center">
-      <td className="py-2">{isNotice ? "공지" : index}</td>
-      <td className="text-left">
+    <tr className="border-b text-center hover:bg-gray-50">
+      <td className="py-3">{isNotice ? "공지" : index}</td>
+      <td className="text-left px-2">
         {isNotice && <span className="text-red-500 mr-1">[공지]</span>}
-        <Link to={`/post/${post.id}`} className="hover:underline block truncate">
+        <Link to={`/post/${post.id}`} className="block truncate hover:underline">
           {post.title}
         </Link>
       </td>

--- a/src/pages/BoardList.tsx
+++ b/src/pages/BoardList.tsx
@@ -54,7 +54,7 @@ export default function BoardList({ board }: Props) {
 
   return (
     <BoardLayout board={board} canWrite={canWrite}>
-      <div className="mb-4">
+      <div className="mb-6">
         <input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
@@ -63,10 +63,10 @@ export default function BoardList({ board }: Props) {
         />
       </div>
       <div className="hidden sm:block">
-        <table className="w-full table-fixed">
-          <thead>
-            <tr className="border-b text-center">
-              <th className="w-12">번호</th>
+        <table className="w-full table-fixed border-t border-b">
+          <thead className="bg-gray-50">
+            <tr className="text-center">
+              <th className="w-12 py-2">번호</th>
               <th className="text-left">제목</th>
               <th className="w-24">작성자</th>
               <th className="w-32">날짜</th>
@@ -80,7 +80,7 @@ export default function BoardList({ board }: Props) {
           </tbody>
         </table>
       </div>
-      <div className="sm:hidden">
+      <div className="sm:hidden space-y-2">
         {posts.map((p, i) => (
           <PostCard key={p.id} post={p} index={posts.length - i} />
         ))}

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -88,15 +88,17 @@ export default function PostDetail() {
   return (
     <BoardLayout board={post.board} canWrite={canWrite}>
       <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
-      <div className="text-sm text-gray-500 mb-4 flex justify-between">
+      <div className="text-sm text-gray-500 mb-4 flex flex-wrap gap-2 justify-between">
         <span>{post.authorName}</span>
         <span>
           {createdAt.toLocaleDateString()} | 조회 {post.views ?? 0}
         </span>
       </div>
-      <div className="whitespace-pre-wrap py-8 border-t border-b mb-4">{post.content}</div>
+      <div className="whitespace-pre-wrap p-6 border rounded mb-4">
+        {post.content}
+      </div>
       {(isOwner || isAdmin) && (
-        <div className="flex gap-2 mb-4">
+        <div className="flex gap-2 mb-8">
           <button
             className="px-3 py-1 border"
             onClick={() => navigate(`/write?board=${post.board}&id=${post.id}`)}
@@ -108,15 +110,7 @@ export default function PostDetail() {
           </button>
         </div>
       )}
-      <div className="mb-8">
-        <button
-          className="px-3 py-1 border"
-          onClick={() => navigate(`/${post.board}`)}
-        >
-          목록으로
-        </button>
-      </div>
-      <div className="mt-8">
+      <section className="mt-8">
         <h2 className="text-lg font-semibold mb-2">댓글</h2>
         {comments.map((c) => (
           <div key={c.id} className="border-t py-2">
@@ -137,6 +131,14 @@ export default function PostDetail() {
           onClick={addComment}
         >
           댓글 달기
+        </button>
+      </section>
+      <div className="mt-8">
+        <button
+          className="px-4 py-2 border rounded"
+          onClick={() => navigate(`/${post.board}`)}
+        >
+          목록으로
         </button>
       </div>
     </BoardLayout>


### PR DESCRIPTION
## Summary
- Emphasize board titles with a wider layout and top-right write button
- Present post lists in bordered tables on desktop and card layouts on mobile
- Add padded content and a comment section with bottom navigation on post details

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0cac25f0832ea53cdc0ea0b47df2