### PR TITLE
feat: improve board and favorites UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { Onboarding } from "./components/Onboarding";
 import { RecommendTray } from "./components/RecommendTray";
 import { TopList } from "./components/TopList";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { toast } from "sonner";
 
 import { websites, categoryConfig, categoryOrder } from "./data/websites";
 import { FavoritesData, CustomSite, Website } from "./types";
@@ -184,30 +185,44 @@ export default function App() {
   };
 
   const toggleFavorite = (websiteId: string) => {
-    const newData = { ...favoritesData };
-    newData.items = newData.items || [];
-    newData.folders = newData.folders || [];
-    newData.widgets = newData.widgets || [];
+    try {
+      const newData = { ...favoritesData };
+      newData.items = newData.items || [];
+      newData.folders = newData.folders || [];
+      newData.widgets = newData.widgets || [];
 
-    const isCurrentlyFavorited = getAllFavoriteIds().includes(websiteId);
+      const isCurrentlyFavorited = getAllFavoriteIds().includes(websiteId);
 
-    if (isCurrentlyFavorited) {
-      newData.items = newData.items.filter((id) => id !== websiteId);
-      newData.folders = newData.folders.map((folder) => ({
-        ...folder,
-        items: (folder?.items || []).filter((id) => id !== websiteId),
-      }));
-    } else {
-      newData.items = [...newData.items, websiteId];
+      if (isCurrentlyFavorited) {
+        newData.items = newData.items.filter((id) => id !== websiteId);
+        newData.folders = newData.folders.map((folder) => ({
+          ...folder,
+          items: (folder?.items || []).filter((id) => id !== websiteId),
+        }));
+      } else {
+        newData.items = [...newData.items, websiteId];
+      }
+
+      setFavoritesData(newData);
+      toast.success(
+        isCurrentlyFavorited
+          ? "즐겨찾기에서 제거되었습니다."
+          : "즐겨찾기에 추가되었습니다."
+      );
+    } catch (e) {
+      toast.error("즐겨찾기 변경에 실패했습니다.");
     }
-
-    setFavoritesData(newData);
   };
 
   const handleAddFav = (id: string) => {
-    setFavoritesData((prev) =>
-      applyPreset(prev, { items: [id], folders: [], widgets: [] })
-    );
+    try {
+      setFavoritesData((prev) =>
+        applyPreset(prev, { items: [id], folders: [], widgets: [] })
+      );
+      toast.success("즐겨찾기에 추가되었습니다.");
+    } catch (e) {
+      toast.error("즐겨찾기 추가에 실패했습니다.");
+    }
   };
 
   const addCustomSite = (site: CustomSite, selectedFolderId: string) => {
@@ -230,6 +245,7 @@ export default function App() {
       newData.items = [...newData.items, site.id];
     }
     setFavoritesData(newData);
+    toast.success("커스텀 사이트가 추가되었습니다.");
   };
 
   const toggleCategory = (category: string) => {
@@ -388,7 +404,7 @@ export default function App() {
             showSampleImage={showSampleImage}
             onShowGuide={() => setShowOnboarding(true)}
             onSaveData={() => {
-              alert("설정이 저장되었습니다!");
+              toast.success("설정이 저장되었습니다!");
             }}
             // ⬇️ 로그인 요청 시 로그인 모달 열기
             onRequestLogin={() => setIsLoginModalOpen(true)}

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from "react-router-dom";
+import { Toaster } from "sonner";
 import App from "./App";
 import BoardList from "./pages/BoardList";
 import PostDetail from "./pages/PostDetail";
@@ -6,12 +7,15 @@ import PostWrite from "./pages/PostWrite";
 
 export default function Root() {
   return (
-    <Routes>
-      <Route path="/" element={<App />} />
-      <Route path="/notice" element={<BoardList board="notice" />} />
-      <Route path="/free" element={<BoardList board="free" />} />
-      <Route path="/post/:id" element={<PostDetail />} />
-      <Route path="/write" element={<PostWrite />} />
-    </Routes>
+    <>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/notice" element={<BoardList board="notice" />} />
+        <Route path="/free" element={<BoardList board="free" />} />
+        <Route path="/post/:id" element={<PostDetail />} />
+        <Route path="/write" element={<PostWrite />} />
+      </Routes>
+      <Toaster position="top-center" />
+    </>
   );
 }

--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -11,6 +11,7 @@ import { BookmarkWidget } from './widgets/BookmarkWidget';
 import { NewsWidget } from './widgets/NewsWidget';
 import { trackVisit, buildFrequencyMap } from '../utils/visitTrack';
 import { sortByMode } from '../utils/sorters';
+import { toast } from 'sonner';
 
 interface FavoritesSectionProps {
   favoritesData: FavoritesData;
@@ -458,6 +459,7 @@ export function FavoritesSectionNew({
       }
 
       onUpdateFavorites(newData);
+      toast.success('즐겨찾기에 추가되었습니다.');
       setDraggedId(null);
       setDraggedFromFolderId(null);
       return;
@@ -562,16 +564,21 @@ export function FavoritesSectionNew({
   };
 
   const removeFromFavorites = (websiteId: string) => {
-    const newData = { ...favoritesData };
-    newData.items = (newData.items || []).filter((id) => id && id !== websiteId);
-    newData.folders = (newData.folders || [])
-      .filter((folder) => folder && folder.id)
-      .map((folder) => ({
-        ...folder,
-        items: (folder?.items || []).filter((id) => id && id !== websiteId),
-      }));
+    try {
+      const newData = { ...favoritesData };
+      newData.items = (newData.items || []).filter((id) => id && id !== websiteId);
+      newData.folders = (newData.folders || [])
+        .filter((folder) => folder && folder.id)
+        .map((folder) => ({
+          ...folder,
+          items: (folder?.items || []).filter((id) => id && id !== websiteId),
+        }));
 
-    onUpdateFavorites(newData);
+      onUpdateFavorites(newData);
+      toast.success('즐겨찾기에서 제거되었습니다.');
+    } catch (e) {
+      toast.error('즐겨찾기 제거에 실패했습니다.');
+    }
   };
 
   const renameFolder = (folderId: string, newName: string) => {

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -5,6 +5,7 @@ import { doc, getDoc } from "firebase/firestore";
 import { auth, db } from "../firebase";
 import { getPost, deletePost, Post, increaseView } from "../libs/posts.repo";
 import BoardLayout from "../components/BoardLayout";
+import { toast } from "sonner";
 
 interface Comment {
   id: number;
@@ -60,8 +61,13 @@ export default function PostDetail() {
   const handleDelete = async () => {
     if (!post) return;
     if (confirm("삭제하시겠습니까?")) {
-      await deletePost(post.id);
-      navigate(`/${post.board}`);
+      try {
+        await deletePost(post.id);
+        toast.success("게시글이 삭제되었습니다.");
+        navigate(`/${post.board}`);
+      } catch (e) {
+        toast.error("게시글 삭제에 실패했습니다.");
+      }
     }
   };
 
@@ -77,6 +83,7 @@ export default function PostDetail() {
       },
     ]);
     setComment("");
+    toast.success("댓글이 등록되었습니다.");
   };
 
   if (!post) return <div className="p-4">Loading...</div>;

--- a/src/pages/PostWrite.tsx
+++ b/src/pages/PostWrite.tsx
@@ -4,6 +4,7 @@ import { User, onAuthStateChanged, signInWithPopup } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 import { auth, provider, db } from "../firebase";
 import { createPost, updatePost, getPost } from "../libs/posts.repo";
+import { toast } from "sonner";
 
 export default function PostWrite() {
   const navigate = useNavigate();
@@ -55,17 +56,23 @@ export default function PostWrite() {
       authorName: user.displayName || user.email || "",
       pinned: board === "notice" ? pinned : false,
     };
-    if (editId) {
-      await updatePost(editId, {
-        title,
-        content,
-        pinned: data.pinned,
-        board: data.board,
-      });
-      navigate(`/post/${editId}`);
-    } else {
-      const id = await createPost(data);
-      navigate(`/post/${id}`);
+    try {
+      if (editId) {
+        await updatePost(editId, {
+          title,
+          content,
+          pinned: data.pinned,
+          board: data.board,
+        });
+        toast.success("게시글이 수정되었습니다.");
+        navigate(`/post/${editId}`);
+      } else {
+        const id = await createPost(data);
+        toast.success("게시글이 작성되었습니다.");
+        navigate(`/post/${id}`);
+      }
+    } catch (e) {
+      toast.error("게시글 저장에 실패했습니다.");
     }
   };
 


### PR DESCRIPTION
## Summary
- show toast notifications across routes
- add success/failure toasts for favorites and board actions
- wire comment section to dummy data with notifications

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1222b224832e88771c63e4132435