### PR TITLE
Add vitest coverage for core features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { FavoritesData, CustomSite, Website } from "./types";
 import "./App.css";
 import { applyPreset } from "./utils/applyPreset";
 import { ARCHITECTURE_STARTER } from "./presets/architecture";
+import { toggleFavorite as toggleFavoriteData } from "./utils/favorites";
 
 
 
@@ -186,23 +187,8 @@ export default function App() {
 
   const toggleFavorite = (websiteId: string) => {
     try {
-      const newData = { ...favoritesData };
-      newData.items = newData.items || [];
-      newData.folders = newData.folders || [];
-      newData.widgets = newData.widgets || [];
-
+      const newData = toggleFavoriteData(favoritesData, websiteId);
       const isCurrentlyFavorited = getAllFavoriteIds().includes(websiteId);
-
-      if (isCurrentlyFavorited) {
-        newData.items = newData.items.filter((id) => id !== websiteId);
-        newData.folders = newData.folders.map((folder) => ({
-          ...folder,
-          items: (folder?.items || []).filter((id) => id !== websiteId),
-        }));
-      } else {
-        newData.items = [...newData.items, websiteId];
-      }
-
       setFavoritesData(newData);
       toast.success(
         isCurrentlyFavorited

--- a/src/utils/favorites.ts
+++ b/src/utils/favorites.ts
@@ -1,0 +1,27 @@
+import { FavoritesData } from "../types";
+
+export function toggleFavorite(data: FavoritesData, websiteId: string): FavoritesData {
+  const newData: FavoritesData = {
+    items: data.items ? [...data.items] : [],
+    folders: data.folders ? data.folders.map(f => ({ ...f, items: [...(f.items || [])] })) : [],
+    widgets: data.widgets ? [...data.widgets] : [],
+  };
+
+  const allIds = [
+    ...newData.items,
+    ...(newData.folders || []).flatMap(f => f.items || []),
+  ];
+  const isFavorited = allIds.includes(websiteId);
+
+  if (isFavorited) {
+    newData.items = newData.items.filter(id => id !== websiteId);
+    newData.folders = (newData.folders || []).map(folder => ({
+      ...folder,
+      items: (folder.items || []).filter(id => id !== websiteId),
+    }));
+  } else {
+    newData.items = [...(newData.items || []), websiteId];
+  }
+
+  return newData;
+}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { mockAuthFunctions } from '../src/lib/supabase';
+
+describe('authentication', () => {
+  it('logs in and returns user data', async () => {
+    const { user, error } = await mockAuthFunctions.signIn('test@example.com', 'password');
+    expect(error).toBeNull();
+    expect(user?.email).toBe('test@example.com');
+  });
+
+  it('logs out without error', async () => {
+    const result = await mockAuthFunctions.signOut();
+    expect(result.error).toBeNull();
+  });
+});

--- a/tests/favorites.test.ts
+++ b/tests/favorites.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { toggleFavorite } from '../src/utils/favorites';
+import type { FavoritesData } from '../src/types';
+
+describe('favorites management', () => {
+  it('adds a favorite when not present', () => {
+    const data: FavoritesData = { items: [], folders: [], widgets: [] };
+    const updated = toggleFavorite(data, 'site1');
+    expect(updated.items).toContain('site1');
+  });
+
+  it('removes a favorite when present', () => {
+    const data: FavoritesData = { items: ['site1'], folders: [], widgets: [] };
+    const updated = toggleFavorite(data, 'site1');
+    expect(updated.items).not.toContain('site1');
+  });
+});

--- a/tests/posts.test.ts
+++ b/tests/posts.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// In-memory store for posts
+const posts: any[] = [];
+
+vi.mock('firebase/firestore', () => ({
+  collection: () => ({}),
+  query: (_col: any, ...conds: any[]) => ({ conds }),
+  where: (field: string, _op: string, value: any) => ({ type: 'where', field, value }),
+  orderBy: (field: string, direction: string) => ({ type: 'orderBy', field, direction }),
+  limit: (n: number) => ({ type: 'limit', n }),
+  startAfter: (last: any) => ({ type: 'startAfter', last }),
+  getDocs: async (q: any) => {
+    let result = posts;
+    const boardCond = q.conds.find((c: any) => c.type === 'where' && c.field === 'board');
+    if (boardCond) result = result.filter((p) => p.board === boardCond.value);
+    const pinnedCond = q.conds.find((c: any) => c.type === 'where' && c.field === 'pinned');
+    if (pinnedCond) result = result.filter((p) => p.pinned === pinnedCond.value);
+    const orderCond = q.conds.find((c: any) => c.type === 'orderBy');
+    if (orderCond) result = result.slice().sort((a, b) => b.createdAt - a.createdAt);
+    const limitCond = q.conds.find((c: any) => c.type === 'limit');
+    if (limitCond) result = result.slice(0, limitCond.n);
+    return { docs: result.map((p) => ({ id: p.id, data: () => p })) };
+  },
+  addDoc: async (_col: any, data: any) => {
+    const id = String(posts.length + 1);
+    posts.push({ id, ...data });
+    return { id };
+  },
+  doc: (_db: any, _col: string, id: string) => ({ id }),
+  getDoc: async (ref: any) => {
+    const post = posts.find((p) => p.id === ref.id);
+    return { exists: () => !!post, id: ref.id, data: () => post };
+  },
+  updateDoc: async (ref: any, data: any) => {
+    const idx = posts.findIndex((p) => p.id === ref.id);
+    if (idx >= 0) posts[idx] = { ...posts[idx], ...data };
+  },
+  deleteDoc: async (ref: any) => {
+    const idx = posts.findIndex((p) => p.id === ref.id);
+    if (idx >= 0) posts.splice(idx, 1);
+  },
+  serverTimestamp: () => Date.now(),
+  increment: (n: number) => n,
+}));
+
+import { createPost, listPosts } from '../src/libs/posts.repo';
+
+describe('posts repository', () => {
+  beforeEach(() => {
+    posts.length = 0;
+  });
+
+  it('creates a post and lists it', async () => {
+    const id = await createPost({
+      board: 'free',
+      title: 'Hello',
+      content: 'World',
+      authorUid: 'u1',
+      authorName: 'User',
+      pinned: false,
+    });
+
+    const { posts: listed } = await listPosts('free');
+    const found = listed.find((p) => p.id === id);
+    expect(found).toBeTruthy();
+    expect(found?.title).toBe('Hello');
+  });
+});


### PR DESCRIPTION
## Summary
- extract favorite toggle logic into reusable util
- add vitest tests for auth, favorites and posts

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb18c2e85c832ea5d5792f2903f0bb