### PR TITLE
feat: persist auth session and sync Firestore data

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -3,7 +3,12 @@
 // Core
 import { initializeApp, getApp, getApps } from "firebase/app";
 // Auth
-import { getAuth, GoogleAuthProvider } from "firebase/auth";
+import {
+  getAuth,
+  GoogleAuthProvider,
+  setPersistence,
+  browserLocalPersistence,
+} from "firebase/auth";
 // Firestore
 import { initializeFirestore } from "firebase/firestore";
 // (optional) Analytics
@@ -31,6 +36,11 @@ const db = initializeFirestore(app, {
 // Auth
 const auth = getAuth(app);
 const provider = new GoogleAuthProvider();
+
+// 세션 유지: 브라우저 재시작 후에도 로그인 상태 복원
+setPersistence(auth, browserLocalPersistence).catch(() => {
+  /* ignore */
+});
 
 // (optional) Analytics - only in browser
 let analytics = null;


### PR DESCRIPTION
## Summary
- persist Firebase Auth session locally and restore user data on load
- push favorite changes to Firestore with realtime snapshot updates
- clear cached user data and show spinner during auth restoration

## Testing
- `npm install` *(fails: ENOTEMPTY rename '/workspace/urwebs/node_modules/firebase')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb205369c4832eabb8c774b36e4450