### PR TITLE
Improve category pagination and layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,6 @@ export default function App() {
   });
   const [customSites, setCustomSites] = useState<CustomSite[]>([]);
   const [showDescriptions, setShowDescriptions] = useState(false);
-  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
 
   // 기타 모달
   const [isContactModalOpen, setIsContactModalOpen] = useState(false);
@@ -267,13 +266,6 @@ export default function App() {
     }
     setFavoritesData(newData);
     toast.success("커스텀 사이트가 추가되었습니다.");
-  };
-
-  const toggleCategory = (category: string) => {
-    const next = new Set(expandedCategories);
-    if (next.has(category)) next.delete(category);
-    else next.add(category);
-    setExpandedCategories(next);
   };
 
   // ---------------------------
@@ -490,17 +482,15 @@ export default function App() {
               <AdBanner text="광고2" />
             </div>
 
-            <div className="flex-1 grid gap-4 xl:grid-cols-6 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2 sm:gap-3">
+            <div className="flex-1 grid gap-6 xl:grid-cols-6 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2 sm:gap-3">
               {categoryOrder.map((category) => (
                 <CategoryCard
                   key={category}
                   category={category}
                   sites={categorizedWebsites[category] || []}
                   config={categoryConfig[category]}
-                  isExpanded={expandedCategories.has(category)}
                   showDescriptions={showDescriptions}
                   favorites={getAllFavoriteIds()}
-                  onToggleCategory={toggleCategory}
                   onToggleFavorite={toggleFavorite}
                 />
               ))}

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -40,7 +40,6 @@ export function StartPage({ favoritesData, onUpdateFavorites, onClose, showDescr
   }, []);
 
   const [currentTime, setCurrentTime] = useState(new Date());
-  const [expandedCategories, setExpandedCategories] = useState<string[]>([]);
 
   useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -76,12 +75,6 @@ export function StartPage({ favoritesData, onUpdateFavorites, onClose, showDescr
     onUpdateFavorites({ ...favoritesData, items: updatedItems });
   };
 
-  const handleToggleCategory = (category: string) => {
-    setExpandedCategories(prev =>
-      prev.includes(category) ? prev.filter(c => c !== category) : [...prev, category]
-    );
-  };
-
   // ✅ websites(상태)를 기준으로 카테고리 묶기
   const categorizedWebsites = useMemo(() => {
     const acc: Record<string, Website[]> = {};
@@ -112,10 +105,10 @@ export function StartPage({ favoritesData, onUpdateFavorites, onClose, showDescr
         </div>
 
         <DndProvider backend={HTML5Backend}>
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
             {/* 즐겨찾기 사이트들 */}
             <div className="lg:col-span-2">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4">즐겨찾기 사이트</h2>
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">즐겨찾기 사이트</h2>
               <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
                 {getFavoriteWebsites().map((site) => (
                   <a
@@ -136,8 +129,8 @@ export function StartPage({ favoritesData, onUpdateFavorites, onClose, showDescr
             </div>
 
             {/* 위젯 영역 */}
-            <div className="lg:col-span-2">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4">위젯</h2>
+            <div className="lg:col-span-2 mt-8 lg:mt-0">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">위젯</h2>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {favoritesData.widgets.map(renderWidget)}
                 {/* 기본 위젯들 ... (생략: 기존 그대로) */}
@@ -145,18 +138,16 @@ export function StartPage({ favoritesData, onUpdateFavorites, onClose, showDescr
             </div>
           </div>
 
-          <h2 className="text-2xl font-bold text-gray-800 mt-8 mb-4">전체 카테고리</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          <h2 className="text-2xl font-bold text-gray-800 mt-12 mb-6">전체 카테고리</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
             {categoryOrder.map(category => (
               <CategoryCard
                 key={category}
                 category={category}
                 sites={categorizedWebsites[category] || []}
                 config={categoryConfig[category]}
-                isExpanded={expandedCategories.includes(category)}
                 showDescriptions={showDescriptions}
                 favorites={favoritesData.items}
-                onToggleCategory={handleToggleCategory}
                 onToggleFavorite={handleToggleFavorite}
               />
             ))}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,10 @@ export interface Website {
   description: string;
   id: string;
   summary?: string; // 새로운 요약 필드
+  // 랭킹 계산을 위한 임시 지표
+  clicks?: number;
+  favorites?: number;
+  addedAt?: number;
 }
 
 export interface CategoryConfig {

--- a/src/utils/rankings.ts
+++ b/src/utils/rankings.ts
@@ -1,0 +1,25 @@
+import { Website } from '../types';
+
+// 인기 사이트: 클릭 수 기준 내림차순
+export function getPopularSites(sites: Website[]): Website[] {
+  return [...sites]
+    .map(site => ({ site, score: site.clicks ?? Math.random() * 100 }))
+    .sort((a, b) => b.score - a.score)
+    .map(({ site }) => site);
+}
+
+// 급상승 사이트: 최근 추가량(addedAt) 기준
+export function getTrendingSites(sites: Website[]): Website[] {
+  return [...sites]
+    .map(site => ({ site, score: site.addedAt ?? 0 }))
+    .sort((a, b) => b.score - a.score)
+    .map(({ site }) => site);
+}
+
+// 자주 담는 사이트: 즐겨찾기 수 기준
+export function getFrequentlyBookmarkedSites(sites: Website[]): Website[] {
+  return [...sites]
+    .map(site => ({ site, score: site.favorites ?? Math.random() * 100 }))
+    .sort((a, b) => b.score - a.score)
+    .map(({ site }) => site);
+}


### PR DESCRIPTION
## Summary
- Expand category cards with incremental loading, infinite scroll, and skeleton placeholders
- Tune page spacing and responsive grids for categories and widgets
- Provide placeholder ranking utilities for popular, trending, and bookmarked sites

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbb6003e0c832e8f4e4a93426633e0