### PR TITLE
feat: add guide samples section

### DIFF
--- a/public/samples/usage-01.svg
+++ b/public/samples/usage-01.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" width="640" height="360">
+  <rect width="640" height="360" rx="16" fill="#f9fafb"/>
+  <text x="32" y="48" font-size="24" font-family="sans-serif" fill="#0f172a">사용 가이드 샘플</text>
+  <text x="32" y="80" font-size="16" font-family="sans-serif" fill="#334155">폴더와 위젯을 이렇게 정리해 보세요</text>
+  <rect x="32" y="120" width="200" height="200" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="48" y="150" font-size="14" font-family="sans-serif" fill="#0f172a">폴더 트리</text>
+  <rect x="272" y="120" width="336" height="200" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="288" y="150" font-size="14" font-family="sans-serif" fill="#0f172a">위젯 배치</text>
+</svg>

--- a/public/samples/usage-02.svg
+++ b/public/samples/usage-02.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" width="640" height="360">
+  <rect width="640" height="360" rx="16" fill="#f9fafb"/>
+  <text x="32" y="48" font-size="24" font-family="sans-serif" fill="#0f172a">모바일/데스크톱 활용 힌트</text>
+  <text x="32" y="80" font-size="16" font-family="sans-serif" fill="#334155">모바일엔 1열 카드, 데스크톱엔 3열 그리드</text>
+  <rect x="32" y="120" width="160" height="200" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+  <rect x="224" y="120" width="384" height="200" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { Onboarding } from "./components/Onboarding";
 import { RecommendTray } from "./components/RecommendTray";
 import { TopList } from "./components/TopList";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import GuideSamples from "./components/GuideSamples";
 import { toast } from "sonner";
 
 import { websites, categoryConfig, categoryOrder } from "./data/websites";
@@ -424,6 +425,8 @@ export default function App() {
             onRequestLogin={() => setIsLoginModalOpen(true)}
             isLoggedIn={!!user}
           />
+
+          <GuideSamples />
 
           <div className="max-w-screen-2xl mx-auto px-5 flex justify-between items-center mb-4">
             <div></div>

--- a/src/components/GuideSamples.tsx
+++ b/src/components/GuideSamples.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import samples from "@/config/guideSamples";
+import { Skeleton } from "./ui/skeleton";
+
+interface Sample {
+  src: string;
+  title: string;
+  caption?: string;
+}
+
+function SampleCard({ sample, onOpen }: { sample: Sample; onOpen: (s: Sample) => void }) {
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState(false);
+
+  return (
+    <figure className="flex-shrink-0 w-72 sm:w-auto rounded-xl border bg-card" key={sample.src}>
+      <button
+        onClick={() => onOpen(sample)}
+        className="block w-full overflow-hidden rounded-t-xl relative"
+        aria-label={`${sample.title} 확대 보기`}
+      >
+        {!error && (
+          <>
+            <img
+              src={sample.src}
+              alt={sample.title}
+              loading="lazy"
+              onLoad={() => setLoaded(true)}
+              onError={() => setError(true)}
+              className={`aspect-[16/9] w-full object-cover transition-opacity ${loaded ? 'opacity-100' : 'opacity-0'}`}
+            />
+            {!loaded && (
+              <Skeleton className="absolute inset-0 aspect-[16/9] w-full" />
+            )}
+          </>
+        )}
+        {error && (
+          <div className="aspect-[16/9] w-full bg-muted flex items-center justify-center text-muted-foreground">
+            이미지를 불러오지 못했습니다
+          </div>
+        )}
+      </button>
+      <figcaption className="p-3">
+        <div className="text-sm font-medium">{sample.title}</div>
+        {sample.caption && <div className="text-xs text-muted-foreground">{sample.caption}</div>}
+      </figcaption>
+    </figure>
+  );
+}
+
+export default function GuideSamples() {
+  const [open, setOpen] = useState<Sample | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(null);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open]);
+
+  return (
+    <section className="mx-auto max-w-6xl px-4 sm:px-6 md:px-8 my-10">
+      <header className="mb-4 flex items-end justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold">사용 가이드 샘플</h2>
+          <p className="text-sm text-muted-foreground">폴더와 위젯을 이렇게 정리해 보세요</p>
+        </div>
+      </header>
+
+      <div className="flex gap-4 overflow-x-auto sm:grid sm:grid-cols-2 lg:grid-cols-3 sm:gap-4">
+        {samples.map((it) => (
+          <SampleCard key={it.src} sample={it} onOpen={(s) => setOpen(s)} />
+        ))}
+      </div>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4"
+          onClick={() => setOpen(null)}
+        >
+          <img
+            src={open.src}
+            alt={open.title}
+            className="max-h-[90vh] max-w-[90vw] rounded-lg shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/config/guideSamples.ts
+++ b/src/config/guideSamples.ts
@@ -1,0 +1,4 @@
+export default [
+  { src: '/samples/usage-01.svg', title: '폴더/위젯 정리 예시 1', caption: '폴더 트리 + 위젯 배치 개념' },
+  { src: '/samples/usage-02.svg', title: '폴더/위젯 정리 예시 2', caption: '모바일/데스크톱 뷰 힌트' },
+];


### PR DESCRIPTION
## Summary
- add text-based sample SVGs
- implement `GuideSamples` component with carousel/grid, lazy loading, skeleton, lightbox
- insert guide samples section on home page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbd4c8d528832e8b4968dc16e521f7