### PR TITLE
feat: align folder and recommendation card heights

### DIFF
--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -155,7 +155,7 @@ function SimpleFolder({
 
   return (
     <div
-      className={`border-2 border-dashed p-3 rounded-lg flex flex-col transition-all cursor-move ${
+      className={`folder-card border-2 border-dashed p-3 rounded-lg flex flex-col transition-all cursor-move ${
         isDraggingOver
           ? 'urwebs-drop-zone'
           : 'bg-gray-50 dark:bg-gray-800 dark:border-gray-600'
@@ -166,7 +166,7 @@ function SimpleFolder({
       onDragLeave={onDragLeaveFolder}
       onDrop={handleDrop}
     >
-      <div className="flex items-center gap-2 mb-2">
+      <div className="controls flex items-center gap-2 mb-2">
         <span className="text-sm">📁</span>
 
         {isEditing ? (
@@ -175,7 +175,7 @@ function SimpleFolder({
               type="text"
               value={editName}
               onChange={(e) => setEditName(e.target.value)}
-              className="flex-1 text-xs font-medium border rounded px-2 py-1 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
+              className="flex-1 border rounded px-2 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
               onKeyDown={(e) => e.key === 'Enter' && handleRename()}
               onBlur={handleRename}
               autoFocus
@@ -183,7 +183,7 @@ function SimpleFolder({
           </div>
         ) : (
           <h3
-            className="text-xs font-medium text-gray-800 cursor-pointer hover:text-blue-600 transition-colors flex-1 dark:text-gray-200 dark:hover:text-blue-400"
+            className="title text-gray-800 cursor-pointer hover:text-blue-600 transition-colors flex-1 dark:text-gray-200 dark:hover:text-blue-400"
             onClick={() => {
               setIsEditing(true);
               setEditName(folder.name);
@@ -201,7 +201,7 @@ function SimpleFolder({
             onChange={(e) =>
               onChangeSortMode(folder.id, e.target.value as SortMode)
             }
-            className="border rounded px-1 py-0.5 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
+            className="border rounded px-1 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
             aria-label="정렬 모드 선택"
           >
             <option value="manual">수동</option>
@@ -805,7 +805,7 @@ export function FavoritesSectionNew({
           <h3 className="font-medium text-gray-700 text-sm dark:text-gray-200">
             📂 폴더
           </h3>
-          <div className="grid gap-3 grid-cols-5">
+          <div className="cards-6cols">
             {Array.isArray(favoritesData.folders) &&
               favoritesData.folders
                 .filter(Boolean)

--- a/src/components/RecommendTray.tsx
+++ b/src/components/RecommendTray.tsx
@@ -17,14 +17,14 @@ const RECOMMENDATIONS: { title: string; preset: FavoritesData }[] = [
 export function RecommendTray({ onApplyPreset }: RecommendTrayProps) {
   return (
     <div className="max-w-screen-2xl mx-auto px-5 sm:px-2 mb-6 mt-6">
-      <div className="grid gap-4 grid-cols-3 sm:grid-cols-2">
+      <div className="cards-6cols">
         {RECOMMENDATIONS.map((rec) => (
           <div
             key={rec.title}
-            className="p-3 border rounded bg-white dark:bg-gray-800"
+            className="card p-3 border rounded bg-white dark:bg-gray-800"
             style={{ borderColor: 'var(--border-urwebs)' }}
           >
-            <h3 className="text-sm font-medium mb-2 text-gray-800 dark:text-gray-100">
+            <h3 className="title mb-2 text-gray-800 dark:text-gray-100">
               {rec.title}
             </h3>
             <button

--- a/src/index.css
+++ b/src/index.css
@@ -5852,3 +5852,31 @@ html, body {
   .mobile-only { display: none !important; }
   .desktop-only { display: block !important; }
 }
+/* Card grid height alignment */
+:root { --card-h: 168px; } /* 필요 시 160~184px 내에서 조정 */
+.cards-6cols { grid-auto-rows: var(--card-h); } /* 동일 행 높이 */
+.card,
+.folder-card {
+  min-height: var(--card-h);
+  max-height: var(--card-h);
+  overflow: hidden;          /* 넘치면 숨김 */
+  display: flex;
+  flex-direction: column;
+}
+
+/* 폴더 카드 내부 여백/요소 높이 정리(내용 과다로 줄넘김 방지) */
+.folder-card { padding: 12px; }
+.folder-card .controls { margin: 4px 0; }
+.folder-card select { height: 30px; }
+.folder-card input[type="text"] { height: 30px; }
+
+/* 텍스트 줄수 제한(제목/설명) */
+.card .title,
+.folder-card .title {
+  font-size: 14px; font-weight: 600;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.card .desc {
+  font-size: 12px; color: #666;
+  overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+}


### PR DESCRIPTION
## Summary
- add global `--card-h` variable and shared card styling
- unify folder and recommendation grids using `cards-6cols`
- constrain folder card controls to fixed height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbeb0b3988832e98f77a92389db64a