### PR TITLE
fix: show favorites after first item

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -467,7 +467,7 @@ export default function App() {
             )}
 
             {/* ✅ Collect + 즐겨찾기 있을 때만 상단 즐겨찾기 & 가이드 표시 */}
-            {!SHOW_ONLY_CATEGORIES && uiMode === "collect" && hasFav && (
+            {uiMode === "collect" && hasFav && (
               <>
                 <FavoritesSectionNew
                   favoritesData={favoritesData}

--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -375,26 +375,6 @@ export function FavoritesSectionNew({
   const [draggedFromFolderId, setDraggedFromFolderId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
 
-  // 첫 즐겨찾기 추가 시 기본 폴더 생성
-  React.useEffect(() => {
-    if (
-      (favoritesData?.items?.length || 0) === 1 &&
-      (favoritesData?.folders?.length || 0) === 0
-    ) {
-      const defaultFolder: FavoriteFolder = {
-        id: 'default-folder-' + Date.now(),
-        name: '자주 방문하는 사이트',
-        items: favoritesData.items || [],
-      };
-
-      onUpdateFavorites({
-        ...favoritesData,
-        items: [],
-        folders: [defaultFolder],
-      });
-    }
-  }, [favoritesData?.items?.length, favoritesData?.folders?.length, onUpdateFavorites]);
-
   const handleDragStart = (e: React.DragEvent, id: string, fromFolderId?: string) => {
     setDraggedId(id);
     setDraggedFromFolderId(fromFolderId || null);

--- a/tests/hasFavorites.test.ts
+++ b/tests/hasFavorites.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { hasFavorites } from '../src/utils/fav';
+
+describe('hasFavorites', () => {
+  it('returns false when no favorites exist', () => {
+    expect(hasFavorites([], [])).toBe(false);
+  });
+
+  it('returns true when bookmarks contain an item', () => {
+    expect(hasFavorites([], ['site1'])).toBe(true);
+  });
+
+  it('returns true when a folder contains an item', () => {
+    expect(hasFavorites([{ items: ['site1'] }], [])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid auto-creating a folder when first favorite is added
- reveal favorites section only after at least one favorite exists
- add tests for hasFavorites utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc19e8afa8832ea9025bf602a7be77