### PR TITLE
Add default sample folder on first favorite

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,6 +171,26 @@ export default function App() {
   }, []);
 
   // ---------------------------
+  // 즐겨찾기 추가 시 기본 폴더 샘플 생성
+  // ---------------------------
+  useEffect(() => {
+    const hasBookmark = favoritesData.items.some(Boolean);
+    const hasFolders = favoritesData.folders.length > 0;
+    if (hasBookmark && !hasFolders) {
+      setFavoritesData((prev) => ({
+        ...prev,
+        folders: [
+          {
+            id: "sample-folder",
+            name: "기본 폴더",
+            items: [],
+          },
+        ],
+      }));
+    }
+  }, [favoritesData.items, favoritesData.folders.length]);
+
+  // ---------------------------
   // 2) 즐겨찾기/커스텀 사이트 변경 시 Firestore & localStorage 저장
   // ---------------------------
   useEffect(() => {

--- a/src/utils/fav.ts
+++ b/src/utils/fav.ts
@@ -4,8 +4,9 @@ export function hasFavorites(
   bookmarks: string[] = []
 ): boolean {
   const hasItems = Array.isArray(bookmarks) && bookmarks.some(Boolean);
+  const hasFolders = Array.isArray(folders) && folders.length > 0;
   const hasFolderItems =
     Array.isArray(folders) &&
     folders.some((f) => Array.isArray(f?.items) && f.items.some(Boolean));
-  return hasItems || hasFolderItems;
+  return hasItems || hasFolderItems || hasFolders;
 }

--- a/tests/hasFavorites.test.ts
+++ b/tests/hasFavorites.test.ts
@@ -13,4 +13,8 @@ describe('hasFavorites', () => {
   it('returns true when a folder contains an item', () => {
     expect(hasFavorites([{ items: ['site1'] }], [])).toBe(true);
   });
+
+  it('returns true when a folder exists even without items', () => {
+    expect(hasFavorites([{ items: [] }], [])).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- create a default folder automatically when a bookmark exists and no folders are present
- count existing folders as favorites in `hasFavorites`
- test `hasFavorites` with empty folders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4ea2a6a8832eb06e88847f1358b1