### PR TITLE
Adjust category layout and handle long site names

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,6 +42,9 @@
   line-height: 1.4;
   display: inline-block;      /* 잘림 방지 */
   color: var(--main-dark);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* 즐겨찾기 안의 사이트 이름 */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -563,19 +563,21 @@ export default function App() {
             )}
 
             {/* ✅ 메인: 카테고리 그리드 (항상 첫 화면에 보이게) */}
-            <div className="grid gap-6 xl:grid-cols-6 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2 sm:gap-3 pt-8">
-              {categoryOrder.map((category) => (
-                <CategoryCard
-                  key={category}
-                  category={category}
-                  sites={categorizedWebsites[category] || []}
-                  config={categoryConfig[category]}
-                  showDescriptions={showDescriptions}
-                  // ✅ (핵심) 즐겨찾기 상태 & 토글 연결
-                  favorites={getAllFavoriteIds()}
-                  onToggleFavorite={toggleFavorite}
-                />
-              ))}
+            <div className="pt-8 max-w-screen-2xl mx-auto px-4 lg:px-8">
+              <div className="grid gap-6 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 sm:gap-3">
+                {categoryOrder.map((category) => (
+                  <CategoryCard
+                    key={category}
+                    category={category}
+                    sites={categorizedWebsites[category] || []}
+                    config={categoryConfig[category]}
+                    showDescriptions={showDescriptions}
+                    // ✅ (핵심) 즐겨찾기 상태 & 토글 연결
+                    favorites={getAllFavoriteIds()}
+                    onToggleFavorite={toggleFavorite}
+                  />
+                ))}
+              </div>
             </div>
 
             {/* startpage, contact, add-site, footer 는 SHOW_ONLY_CATEGORIES 일 땐 계속 숨김 */}

--- a/src/components/ContactModal.tsx
+++ b/src/components/ContactModal.tsx
@@ -5,9 +5,10 @@ interface ContactModalProps { // 컴포넌트가 받는 props의 타입을 정�
   onClose: () => void; // 모달 창을 닫는 함수입니다.
 }
 
-export function ContactModal({ isOpen, onClose }: ContactModalProps) { // ContactModal 컴포넌트를 정의합니다.
-  const [email, setEmail] = useState(''); // 사용자의 이메일을 저장하는 상태입니다.
-  const [message, setMessage] = useState(''); // 사용자의 문의 내용을 저장하는 상태입니다.
+  export function ContactModal({ isOpen, onClose }: ContactModalProps) { // ContactModal 컴포넌트를 정의합니다.
+    const [email, setEmail] = useState(''); // 사용자의 이메일을 저장하는 상태입니다.
+    const [message, setMessage] = useState(''); // 사용자의 문의 내용을 저장하는 상태입니다.
+    const RECIPIENT_EMAIL = 'okjsk1@gmail.com';
 
   useEffect(() => { // 모달 창이 열렸을 때 키보드 이벤트를 처리하기 위한 효과(effect)입니다.
     const handleEscape = (e: KeyboardEvent) => { // 'Escape' 키를 눌렀을 때 모달을 닫는 함수입니다.
@@ -37,7 +38,7 @@ export function ContactModal({ isOpen, onClose }: ContactModalProps) { // Contac
 문의내용:
 ${message}`); // 이메일 본문 내용을 URL에 맞게 인코딩합니다.
     
-    window.location.href = `mailto:okjsk1@gmail.com?subject=${subject}&body=${body}`; // 기본 이메일 클라이언트를 실행하고, 제목과 본문을 채워넣습니다.
+      window.location.href = `mailto:${RECIPIENT_EMAIL}?subject=${subject}&body=${body}`; // 기본 이메일 클라이언트를 실행하고, 제목과 본문을 채워넣습니다.
     
     // 폼 초기화
     setEmail('');


### PR DESCRIPTION
## Summary
- Constrain category grid to header width and use 6-column layout
- Add ellipsis styling so long site names are truncated
- Route contact inquiries to okjsk1@gmail.com

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc51c94cc8832ebe5795b32939a919