### PR TITLE
Fix undefined onDrop handler in Favorites section

### DIFF
--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -171,7 +171,7 @@ function SimpleFolder({
       onDragStart={handleFolderDragStart}
       onDragOver={onDragOverFolder}
       onDragLeave={onDragLeaveFolder}
-      onDrop={onDrop}
+      onDrop={handleDrop}
     >
       <div className="controls flex items-center gap-2 mb-2">
         <span className="text-sm">📁</span>


### PR DESCRIPTION
## Summary
- Fix ReferenceError by wiring folder drop event to local handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc54ccabe8832ea6ecd37bb3d8a417