### PR TITLE
chore: tighten layout spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -479,7 +479,7 @@ export default function App() {
               />
             )}
 
-            <div className="mx-auto max-w-[1280px] px-6 lg:px-8">
+            <div className="mx-auto max-w-[1200px] px-4 lg:px-6">
               {/* 즐겨찾기 & 폴더: 즐겨찾기가 있을 때만 상단에 표시 */}
               {hasFav && (
                 <FavoritesSectionNew
@@ -493,7 +493,7 @@ export default function App() {
               )}
 
               {/* ✅ 메인: 카테고리 그리드 (항상 첫 화면에 보이게) */}
-              <section className="mt-8 grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-4 lg:gap-6">
+              <section className="mt-6 grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6">
                 {categoryOrder.map((category) => (
                   <CategoryCard
                     key={category}
@@ -558,7 +558,7 @@ export default function App() {
                   </div>
 
                   {/* 내용: FavoritesSectionNew를 그대로 삽입 (내부 스크롤) */}
-                  <div className="max-h-[300px] overflow-auto p-4 max-w-[1280px] mx-auto">
+                  <div className="max-h-[300px] overflow-auto p-4 max-w-[1200px] mx-auto">
                     {hasFav ? (
                       <FavoritesSectionNew
                         favoritesData={favoritesData}

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -62,7 +62,7 @@ export function CategoryCard({
   const hasMore = visibleCount < safeSites.length;
 
   return (
-    <div className="urwebs-category-card h-full w-full rounded-xl border bg-white p-4 flex flex-col shadow-sm dark:bg-gray-900">
+    <div className="urwebs-category-card h-full w-full rounded-xl border bg-white p-3 lg:p-4 flex flex-col shadow-sm dark:bg-gray-900">
       <div className="flex items-center gap-3 px-4 py-4">
         <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
           {config.icon}

--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -638,7 +638,7 @@ export function FavoritesSectionNew({
   return (
     <section
       id="favorites-section"
-      className="mx-auto max-w-[1280px] px-6 lg:px-8 py-8 transition-colors duration-300"
+      className="mx-auto max-w-[1200px] px-4 lg:px-6 py-8 transition-colors duration-300"
     >
       {/* 헤더 버튼 그룹 */}
       <div className="flex items-center justify-between mb-4">
@@ -747,7 +747,7 @@ export function FavoritesSectionNew({
           <h3 className="font-medium text-gray-700 text-sm mb-3 dark:text-gray-200">
             🔧 위젯
           </h3>
-          <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-4 lg:gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6">
             {(favoritesData.widgets || [])
               .filter((w) => w && w.id)
               .map((w) => (
@@ -758,9 +758,9 @@ export function FavoritesSectionNew({
       )}
 
       {/* 즐겨찾기 & 폴더 */}
-      <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-4 lg:gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6">
         {/* 즐겨찾기 리스트 */}
-        <div className="col-span-1 space-y-3 md:col-span-1 xl:col-span-1">
+        <div className="col-span-1 space-y-2 lg:space-y-3 md:col-span-1 xl:col-span-1">
           <div className="flex items-center justify-between">
             <h3 className="font-medium text-gray-700 text-sm dark:text-gray-200">
               📌 즐겨찾기
@@ -797,7 +797,7 @@ export function FavoritesSectionNew({
         </div>
 
         {/* 폴더들 */}
-        <div className="space-y-3 md:col-span-2 xl:col-span-5">
+        <div className="space-y-2 lg:space-y-3 md:col-span-2 xl:col-span-5">
           <h3 className="font-medium text-gray-700 text-sm dark:text-gray-200">
             📂 폴더
           </h3>

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -146,7 +146,7 @@ export function StartPage({ favoritesData, onUpdateFavorites, onClose, showDescr
               <div>
                 <h2 className="text-2xl font-bold text-gray-800 mb-6">전체 카테고리</h2>
                 <div
-                  className="grid gap-6"
+                  className="grid gap-x-4 gap-y-6"
                   style={{
                     gridTemplateColumns:
                       "repeat(auto-fit, minmax(280px, 1fr))",

--- a/src/components/widgets/ClockWidget.tsx
+++ b/src/components/widgets/ClockWidget.tsx
@@ -16,7 +16,7 @@ export function ClockWidget({ id, onRemove }: ClockWidgetProps) {
   }, []);
 
   return (
-    <div className="bg-white rounded-lg border shadow-sm p-4 h-full flex flex-col">
+    <div className="bg-white rounded-lg border shadow-sm p-3 lg:p-4 h-full flex flex-col">
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-medium text-gray-800 text-sm">🕐 시계</h3>
         <button

--- a/src/components/widgets/DdayWidget.tsx
+++ b/src/components/widgets/DdayWidget.tsx
@@ -46,7 +46,7 @@ export function DdayWidget({ id, onRemove }: DdayWidgetProps) {
   };
 
   return (
-    <div className="bg-white p-4 rounded-lg shadow-sm border h-full relative">
+    <div className="bg-white p-3 lg:p-4 rounded-lg shadow-sm border h-full relative">
       <div className="flex justify-between items-center mb-3">
         <h3 className="text-sm font-medium text-gray-800">⏰ D-Day</h3>
         <button
@@ -58,7 +58,7 @@ export function DdayWidget({ id, onRemove }: DdayWidgetProps) {
       </div>
 
       {isEditing || (!targetDate || !title) ? (
-        <div className="space-y-3">
+        <div className="space-y-2 lg:space-y-3">
           <input
             type="text"
             value={title}

--- a/src/components/widgets/MemoWidget.tsx
+++ b/src/components/widgets/MemoWidget.tsx
@@ -20,7 +20,7 @@ export function MemoWidget({ id, onRemove }: MemoWidgetProps) {
   };
 
   return (
-    <div className="bg-white rounded-lg border shadow-sm p-4 h-full flex flex-col">
+    <div className="bg-white rounded-lg border shadow-sm p-3 lg:p-4 h-full flex flex-col">
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-medium text-gray-800 text-sm">📝 메모</h3>
         <button

--- a/src/components/widgets/TodoWidget.tsx
+++ b/src/components/widgets/TodoWidget.tsx
@@ -56,7 +56,7 @@ export function TodoWidget({ id, onRemove }: TodoWidgetProps) {
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 shadow-sm p-4 h-full flex flex-col">
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 shadow-sm p-3 lg:p-4 h-full flex flex-col">
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-medium text-gray-800 dark:text-gray-200 text-sm">✅ 할 일</h3>
         <button

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -123,7 +123,7 @@ export function WeatherWidget({ id, onRemove, type = 'current' }: WeatherWidgetP
   };
 
   return (
-    <div className="bg-white rounded-lg border shadow-sm p-4 h-full flex flex-col">
+    <div className="bg-white rounded-lg border shadow-sm p-3 lg:p-4 h-full flex flex-col">
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-medium text-gray-800 text-xs">{getTitle()}</h3>
         <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- reduce container width and padding for tighter layout
- narrow horizontal gaps and adjust section margins
- shrink card padding and list spacing in widgets and favorites

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5eb9191c832e9be1a7c96c7ef82d