### PR TITLE
Align favorites and category grids to six-column layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -503,7 +503,7 @@ export default function App() {
                 )}
 
                 {/* ✅ 메인: 카테고리 그리드 (항상 첫 화면에 보이게) */}
-                <section className="mt-6 grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6">
+                <section className="mt-6 cards-6cols">
                   {categoryOrder.map((category) => (
                     <CategoryCard
                       key={category}

--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -757,10 +757,12 @@ export function FavoritesSectionNew({
         </div>
       )}
 
-      {/* 즐겨찾기 & 폴더 */}
-      <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6">
-        {/* 즐겨찾기 리스트 */}
-        <div className="col-span-1 space-y-2 lg:space-y-3 md:col-span-1 xl:col-span-1">
+      <h3 className="font-medium text-gray-700 text-sm dark:text-gray-200 mb-3">
+        📂 폴더
+      </h3>
+      <div className="cards-6cols">
+        {/* 즐겨찾기 리스트 (좌측 1열) */}
+        <div className="space-y-2 lg:space-y-3">
           <div className="flex items-center justify-between">
             <h3 className="font-medium text-gray-700 text-sm dark:text-gray-200">
               📌 즐겨찾기
@@ -796,60 +798,53 @@ export function FavoritesSectionNew({
           </div>
         </div>
 
-        {/* 폴더들 */}
-        <div className="space-y-2 lg:space-y-3 md:col-span-2 xl:col-span-5">
-          <h3 className="font-medium text-gray-700 text-sm dark:text-gray-200">
-            📂 폴더
-          </h3>
-          <div className="cards-6cols">
-            {Array.isArray(favoritesData.folders) &&
-              favoritesData.folders
-                .filter(Boolean)
-                .map((folder) => {
-                  const folderItems = Array.isArray(folder?.items)
-                    ? folder.items.filter(Boolean)
-                    : [];
-                  const sortedItems = sortByMode(
-                    folderItems,
-                    folder.sortMode || 'manual',
-                    freqMap,
-                    titleMap,
-                  ); // [sorting]
-                  return (
-                    <SimpleFolder
-                      key={folder.id}
-                      folder={folder}
-                      onRenameFolder={renameFolder}
-                      onDeleteFolder={deleteFolder}
-                      onDropWebsite={moveWebsiteToFolder}
-                      onDragOverFolder={(e) => handleDragOver(e, folder.id)}
-                      onDragLeaveFolder={handleDragLeave}
-                      isDraggingOver={dragOverId === folder.id}
-                      onChangeSortMode={changeFolderSortMode} // [sorting]
-                    >
-                      {sortedItems.map((id) => (
-                        <SimpleWebsite
-                          key={id}
-                          websiteId={id}
-                          onRemove={removeFromFavorites}
-                          onDragStart={(e) => handleDragStart(e, id, folder.id)}
-                          onDragOver={(e) => handleDragOver(e, id)}
-                          onDragLeave={handleDragLeave}
-                          onDrop={(e) => handleDrop(e, id)}
-                          isDraggingOver={dragOverId === id}
-                        />
-                      ))}
+        {/* 폴더 카드들 (우측 5열) */}
+        {Array.isArray(favoritesData.folders) &&
+          favoritesData.folders
+            .filter(Boolean)
+            .map((folder) => {
+              const folderItems = Array.isArray(folder?.items)
+                ? folder.items.filter(Boolean)
+                : [];
+              const sortedItems = sortByMode(
+                folderItems,
+                folder.sortMode || 'manual',
+                freqMap,
+                titleMap,
+              ); // [sorting]
+              return (
+                <SimpleFolder
+                  key={folder.id}
+                  folder={folder}
+                  onRenameFolder={renameFolder}
+                  onDeleteFolder={deleteFolder}
+                  onDropWebsite={moveWebsiteToFolder}
+                  onDragOverFolder={(e) => handleDragOver(e, folder.id)}
+                  onDragLeaveFolder={handleDragLeave}
+                  isDraggingOver={dragOverId === folder.id}
+                  onChangeSortMode={changeFolderSortMode} // [sorting]
+                >
+                  {sortedItems.map((id) => (
+                    <SimpleWebsite
+                      key={id}
+                      websiteId={id}
+                      onRemove={removeFromFavorites}
+                      onDragStart={(e) => handleDragStart(e, id, folder.id)}
+                      onDragOver={(e) => handleDragOver(e, id)}
+                      onDragLeave={handleDragLeave}
+                      onDrop={(e) => handleDrop(e, id)}
+                      isDraggingOver={dragOverId === id}
+                    />
+                  ))}
 
-                      {sortedItems.length === 0 && (
-                        <p className="text-xs text-gray-500 italic dark:text-gray-400">
-                          폴더가 비어있습니다
-                        </p>
-                      )}
-                    </SimpleFolder>
-                  );
-                })}
-          </div>
-        </div>
+                  {sortedItems.length === 0 && (
+                    <p className="text-xs text-gray-500 italic dark:text-gray-400">
+                      폴더가 비어있습니다
+                    </p>
+                  )}
+                </SimpleFolder>
+              );
+            })}
       </div>
     </section>
   );

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -145,13 +145,7 @@ export function StartPage({ favoritesData, onUpdateFavorites, onClose, showDescr
 
               <div>
                 <h2 className="text-2xl font-bold text-gray-800 mb-6">전체 카테고리</h2>
-                <div
-                  className="grid gap-x-4 gap-y-6"
-                  style={{
-                    gridTemplateColumns:
-                      "repeat(auto-fit, minmax(280px, 1fr))",
-                  }}
-                >
+                <div className="cards-6cols">
                   {categoryOrder.map((category) => (
                     <CategoryCard
                       key={category}

--- a/src/index.css
+++ b/src/index.css
@@ -5854,7 +5854,12 @@ html, body {
 }
 /* Card grid height alignment */
 :root { --card-h: 168px; } /* 필요 시 160~184px 내에서 조정 */
-.cards-6cols { grid-auto-rows: var(--card-h); } /* 동일 행 높이 */
+.cards-6cols {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 16px;
+  grid-auto-rows: var(--card-h); /* 동일 행 높이 */
+}
 .card,
 .folder-card {
   min-height: var(--card-h);


### PR DESCRIPTION
## Summary
- Ensure favorites section uses six-column grid with dedicated first column for favorite list
- Standardize category grids across app to fixed six-column width
- Add reusable `cards-6cols` style for consistent card sizing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc7a1a2338832eb0d220ae133882b4