### PR TITLE
Fix grid overflow and enforce desktop container width

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5831,30 +5831,45 @@ html {
   color: var(--main-dark);
 }
 /*# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiQXBwLmNzcyJdLAogICJzb3VyY2VzQ29udGVudCI6IFsiLyogXHVCQUE4XHVCMkVDIFx1QzYyNFx1QkM4NFx1QjgwOFx1Qzc3NCAqL1xuLm1vZGFsLW92ZXJsYXkge1xuICBwb3NpdGlvbjogZml4ZWQ7XG4gIHRvcDogMDtcbiAgbGVmdDogMDtcbiAgd2lkdGg6IDEwMCU7XG4gIGhlaWdodDogMTAwJTtcbiAgYmFja2dyb3VuZC1jb2xvcjogcmdiYSgwLCAwLCAwLCAwLjUpO1xuICBkaXNwbGF5OiBmbGV4O1xuICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgei1pbmRleDogMTAwMDsgLyogXHVDNzc0IFx1QUMxMlx1Qzc0NCB6LVs5OTk5XSBcdUJDRjRcdUIyRTRcdUIyOTQgXHVCMEFFXHVBQzhDIFx1QzcyMFx1QzlDMFx1RDU2OVx1QjJDOFx1QjJFNC4gKi9cbn1cblxuLyogVXNlckd1aWRlIFx1QkFBOFx1QjJFQyAqL1xuLnVzZXItZ3VpZGUtbW9kYWwge1xuICBwb3NpdGlvbjogZml4ZWQ7XG4gIHRvcDogMDtcbiAgbGVmdDogMDtcbiAgd2lkdGg6IDEwMCU7XG4gIGhlaWdodDogMTAwJTtcbiAgYmFja2dyb3VuZC1jb2xvcjogcmdiYSgwLCAwLCAwLCAwLjcpO1xuICBkaXNwbGF5OiBmbGV4O1xuICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgei1pbmRleDogMjAwMDsgLyogXHVDNzc0IFx1QUMxMlx1Qzc0NCB6LVs5OTk5XSBcdUJDRjRcdUIyRTRcdUIyOTQgXHVCMEFFXHVBQzhDIFx1QzcyMFx1QzlDMFx1RDU2OVx1QjJDOFx1QjJFNC4gKi9cbn1cblxuLyogXHVDRTc0XHVEMTRDXHVBQ0UwXHVCOUFDIFx1Q0U3NFx1QjREQyBcdUM4MUNcdUJBQTkgKFx1QzYwODogXHVEODNEXHVEQ0MyIFx1RDNGNFx1QjM1NCwgXHVEODNEXHVEQ0NDIFx1Qzk5MFx1QUNBOFx1Q0MzRVx1QUUzMCkgKi9cbi51cndlYnMtY2F0ZWdvcnktY2FyZCBoMyB7XG4gIGZvbnQtc2l6ZTogMXJlbTsgICAgICAgICAgIC8qIFx1QUUwMFx1Qzc5MCBcdUQwNkNcdUFFMzAgKi9cbiAgZm9udC13ZWlnaHQ6IDYwMDsgICAgICAgICAgLyogXHVBQzE1XHVDODcwICovXG4gIGxldHRlci1zcGFjaW5nOiAwLjVweDsgICAgIC8qIFx1Qzc5MFx1QUMwNCAqL1xuICBjb2xvcjogdmFyKC0tbWFpbi1kYXJrKTsgICAvKiBcdUMwQUNcdUM3NzRcdUQyQjggXHVEMUE0XHVBQ0ZDIFx1QjlERVx1Q0RBNCAqL1xufVxuXG4vKiBcdUFDMUNcdUJDQzQgXHVDMEFDXHVDNzc0XHVEMkI4IFx1Qzc3NFx1Qjk4NCAoXHVDRTc0XHVCNERDIFx1QzU0OFx1Qzc1OCBcdUI5QzFcdUQwNkMpICovXG4udXJ3ZWJzLXdlYnNpdGUtaXRlbSBhIHtcbiAgZm9udC1zaXplOiAwLjlyZW07ICAgICAgICAgIC8qIFx1QUUwMFx1Qzc5MCBcdUQwNkNcdUFFMzAgKi9cbiAgZm9udC13ZWlnaHQ6IDUwMDtcbiAgbGV0dGVyLXNwYWNpbmc6IDAuM3B4OyAgICAgIC8qIFx1Qzc5MFx1QUMwNCAqL1xuICBsaW5lLWhlaWdodDogMS40O1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7ICAgICAgLyogXHVDNzk4XHVCOUJDIFx1QkMyOVx1QzlDMCAqL1xuICBjb2xvcjogdmFyKC0tbWFpbi1kYXJrKTtcbn1cblxuLyogXHVDOTkwXHVBQ0E4XHVDQzNFXHVBRTMwIFx1QzU0OFx1Qzc1OCBcdUMwQUNcdUM3NzRcdUQyQjggXHVDNzc0XHVCOTg0ICovXG4udXJ3ZWJzLWZhdm9yaXRlLWl0ZW0gYSB7XG4gIGZvbnQtc2l6ZTogMC44NXJlbTtcbiAgZm9udC13ZWlnaHQ6IDUwMDtcbiAgbGV0dGVyLXNwYWNpbmc6IDAuM3B4O1xuICBsaW5lLWhlaWdodDogMS40O1xuICBjb2xvcjogdmFyKC0tbWFpbi1kYXJrKTtcbn1cbiJdLAogICJtYXBwaW5ncyI6ICI7QUFDQSxDQUFDO0FBQ0MsWUFBVTtBQUNWLE9BQUs7QUFDTCxRQUFNO0FBQ04sU0FBTztBQUNQLFVBQVE7QUFDUixvQkFBa0IsS0FBSyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRTtBQUNoQyxXQUFTO0FBQ1QsbUJBQWlCO0FBQ2pCLGVBQWE7QUFDYixXQUFTO0FBQ1g7QUFHQSxDQUFDO0FBQ0MsWUFBVTtBQUNWLE9BQUs7QUFDTCxRQUFNO0FBQ04sU0FBTztBQUNQLFVBQVE7QUFDUixvQkFBa0IsS0FBSyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRTtBQUNoQyxXQUFTO0FBQ1QsbUJBQWlCO0FBQ2pCLGVBQWE7QUFDYixXQUFTO0FBQ1g7QUFHQSxDQUFDLHFCQUFxQjtBQUNwQixhQUFXO0FBQ1gsZUFBYTtBQUNiLGtCQUFnQjtBQUNoQixTQUFPLElBQUk7QUFDYjtBQUdBLENBQUMsb0JBQW9CO0FBQ25CLGFBQVc7QUFDWCxlQUFhO0FBQ2Isa0JBQWdCO0FBQ2hCLGVBQWE7QUFDYixXQUFTO0FBQ1QsU0FBTyxJQUFJO0FBQ2I7QUFHQSxDQUFDLHFCQUFxQjtBQUNwQixhQUFXO0FBQ1gsZUFBYTtBQUNiLGtCQUFnQjtBQUNoQixlQUFhO0FBQ2IsU0FBTyxJQUFJO0FBQ2I7IiwKICAibmFtZXMiOiBbXQp9Cg== */
-:root { --desktop-width: 1280px; }
-html, body {
-  min-width: var(--desktop-width);
-  overflow-x: auto;
-}
-.container, #root, .app {
-  width: var(--desktop-width);
+/* Desktop layout variables */
+*, *::before, *::after { box-sizing: border-box; }
+
+:root { --desktop-width: 1280px; --gap: 16px; --card-h: 168px; } /* 필요 시 160~184px 내에서 조정 */
+
+html, body { min-width: var(--desktop-width); }
+
+#root, .app, .container {
+  max-width: var(--desktop-width);
   margin: 0 auto;
+  padding-left: var(--gap);
+  padding-right: var(--gap);
 }
-.grid, .cards {
+
+.cards-6cols {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 16px;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: var(--gap);
+  grid-auto-rows: var(--card-h); /* 동일 행 높이 */
 }
-.mobile-only { display: none !important; }
-@media (max-width: 1279px) {
-  .container, #root, .app { width: var(--desktop-width); }
-  .grid, .cards { grid-template-columns: repeat(6, 1fr); }
-  .mobile-only { display: none !important; }
-  .desktop-only { display: block !important; }
+.cards-6cols > * { min-width: 0; }
+
+.page-grid {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: var(--gap);
 }
-/* Card grid height alignment */
-:root { --card-h: 168px; } /* 필요 시 160~184px 내에서 조정 */
-.cards-6cols { grid-auto-rows: var(--card-h); } /* 동일 행 높이 */
+.page-main { min-width: 0; }
+.page-aside { width: 300px; min-width: 300px; }
+
+.section, .category-card {
+  margin: 0;
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+}
+.category-card .inner { overflow: hidden; }
+
+/* Development mode: prevent horizontal scroll */
+body { overflow-x: hidden; }
 .card,
 .folder-card {
   min-height: var(--card-h);


### PR DESCRIPTION
## Summary
- ensure global box-sizing and fixed desktop container width with padding
- make 6-column card grid and 2-column page layouts shrink without overflow
- remove stray margins and prevent horizontal scrolling in development

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc80b3ed3c832e968dd5435bd16024