### PR TITLE
fix: constrain category grid and prevent overflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -503,19 +503,23 @@ export default function App() {
                 )}
 
                 {/* ✅ 메인: 카테고리 그리드 (항상 첫 화면에 보이게) */}
-                <section className="mt-6 grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6">
-                  {categoryOrder.map((category) => (
-                    <CategoryCard
-                      key={category}
-                      category={category}
-                      sites={categorizedWebsites[category] || []}
-                      config={categoryConfig[category]}
-                      showDescriptions={showDescriptions}
-                      // ✅ (핵심) 즐겨찾기 상태 & 토글 연결
-                      favorites={getAllFavoriteIds()}
-                      onToggleFavorite={toggleFavorite}
-                    />
-                  ))}
+                <section className="mt-6 w-full overflow-x-hidden">
+                  <div className="mx-auto w-full max-w-[1180px] px-4 sm:px-5 lg:px-6">
+                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6 min-w-0">
+                      {categoryOrder.map((category) => (
+                        <CategoryCard
+                          key={category}
+                          category={category}
+                          sites={categorizedWebsites[category] || []}
+                          config={categoryConfig[category]}
+                          showDescriptions={showDescriptions}
+                          // ✅ (핵심) 즐겨찾기 상태 & 토글 연결
+                          favorites={getAllFavoriteIds()}
+                          onToggleFavorite={toggleFavorite}
+                        />
+                      ))}
+                    </div>
+                  </div>
                 </section>
               </div>
             </div>

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -62,7 +62,7 @@ export function CategoryCard({
   const hasMore = visibleCount < safeSites.length;
 
   return (
-    <div className="urwebs-category-card h-full w-full rounded-xl border bg-white p-3 lg:p-4 flex flex-col shadow-sm dark:bg-gray-900">
+    <div className="urwebs-category-card h-full w-full min-w-0 rounded-xl border bg-white p-3 lg:p-4 flex flex-col shadow-sm dark:bg-gray-900">
       <div className="flex items-center gap-3 px-4 py-4">
         <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
           {config.icon}


### PR DESCRIPTION
## Summary
- contain category card grid to max width and center it to prevent horizontal overflow
- add min-w-0 to cards so grid items shrink properly

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcfb2f39c4832eadfd6e1e295e2656