### PR TITLE
Increase site card width and shrink title text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -505,7 +505,7 @@ export default function App() {
                 {/* ✅ 메인: 카테고리 그리드 (항상 첫 화면에 보이게) */}
                 <section className="mt-6 w-full overflow-x-hidden">
                   <div className="mx-auto w-full max-w-[1180px] px-4 sm:px-5 lg:px-6">
-                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6 min-w-0">
+                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-5 gap-x-4 gap-y-6 min-w-0">
                       {categoryOrder.map((category) => (
                         <CategoryCard
                           key={category}

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -149,7 +149,7 @@ export function StartPage({ favoritesData, onUpdateFavorites, onClose, showDescr
                   className="grid gap-x-4 gap-y-6"
                   style={{
                     gridTemplateColumns:
-                      "repeat(auto-fit, minmax(280px, 1fr))",
+                      "repeat(auto-fit, minmax(300px, 1fr))",
                   }}
                 >
                   {categoryOrder.map((category) => (

--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -47,7 +47,8 @@ export function WebsiteItem({
           href={website.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="block text-sm text-[var(--main-dark)] truncate focus:outline-none"
+          className="block text-[var(--main-dark)] truncate focus:outline-none"
+          style={{ fontSize: "13.5px" }}
           title={!showDescription ? website.description : undefined}
           onClick={() => trackVisit(website.id)}
         >


### PR DESCRIPTION
## Summary
- widen main category grid so site cards have more room
- shrink website title text slightly to prevent clipping
- expand start page category grid card width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd05e66c78832e8da29203085d64c5