### PR TITLE
chore: adjust WebsiteItem link font size

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -48,7 +48,7 @@ export function WebsiteItem({
           target="_blank"
           rel="noopener noreferrer"
           className="block text-[var(--main-dark)] truncate focus:outline-none"
-          style={{ fontSize: "13.5px" }}
+          style={{ fontSize: "12.5px" }}
           title={!showDescription ? website.description : undefined}
           onClick={() => trackVisit(website.id)}
         >


### PR DESCRIPTION
## Summary
- tweak website item link font size to 12.5px for better alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd0cac5fbc832ea09abe7863fea832