### PR TITLE
Reduce padding on website title boxes

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -35,7 +35,7 @@ export function WebsiteItem({
 
   return (
     <div
-      className="urwebs-website-item flex items-center gap-2 px-2 min-h-9 rounded-md min-w-0 flex-1 overflow-hidden hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
+      className="urwebs-website-item flex items-center gap-2 px-1 min-h-9 rounded-md min-w-0 flex-1 overflow-hidden hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
       style={{ height: showDescription ? "auto" : undefined }}
       draggable={isDraggable}
       onDragStart={handleDragStart}


### PR DESCRIPTION
## Summary
- shrink horizontal padding for website item rows to tighten layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd316efb6c832eb7310c097855ee04