### PR TITLE
fix: improve site title layout

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -63,7 +63,7 @@ export function CategoryCard({
 
   return (
     <div className="urwebs-category-card h-full w-full min-w-0 rounded-xl border bg-white p-3 lg:p-4 flex flex-col shadow-sm dark:bg-gray-900">
-      <div className="flex items-center gap-3 px-4 py-4">
+      <div className="flex items-center gap-3 px-3 py-4">
         <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
           {config.icon}
         </span>
@@ -79,7 +79,7 @@ export function CategoryCard({
       </div>
 
       {/* 사이트 목록 영역 */}
-      <div className="flex-1 flex flex-col min-h-0 px-4 pb-4">
+      <div className="flex-1 flex flex-col min-h-0 px-3 pb-4">
         <div className="flex flex-col gap-0.5 overflow-y-auto">
           {safeSites.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-6 text-gray-500 text-xs">

--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -35,7 +35,7 @@ export function WebsiteItem({
 
   return (
     <div
-      className="urwebs-website-item flex items-center gap-2 px-1 min-h-9 rounded-md min-w-0 flex-1 overflow-hidden hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
+      className="urwebs-website-item flex items-center gap-2 px-1 min-h-9 rounded-md min-w-0 flex-1 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
       style={{ height: showDescription ? "auto" : undefined }}
       draggable={isDraggable}
       onDragStart={handleDragStart}
@@ -87,7 +87,7 @@ export function WebsiteItem({
 
       <button
         onClick={handleFavoriteClick}
-        className="ml-auto bg-transparent border-0 p-1 flex items-center cursor-pointer rounded transition-colors hover:bg-pink-100"
+        className="ml-1 flex-shrink-0 bg-transparent border-0 p-1 flex items-center cursor-pointer rounded transition-colors hover:bg-pink-100"
         aria-label="즐겨찾기"
       >
         <svg


### PR DESCRIPTION
## Summary
- prevent long site titles from overlapping with the favorite icon by adjusting layout
- widen site title area by trimming category card side padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd42c7ec2c832e8061950ebfaff0f2