### PR TITLE
fix star icon overlapping site titles

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -35,7 +35,7 @@ export function WebsiteItem({
 
   return (
     <li
-      className="urwebs-website-item flex items-center gap-2 px-2 py-1 min-h-9 rounded-md min-w-0 flex-1 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
+      className="urwebs-website-item relative flex items-center gap-2 pl-2 pr-8 py-1 min-h-9 rounded-md min-w-0 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
       style={{ height: showDescription ? "auto" : undefined }}
       draggable={isDraggable}
       onDragStart={handleDragStart}
@@ -88,7 +88,7 @@ export function WebsiteItem({
       <button
         onClick={handleFavoriteClick}
         aria-label="즐겨찾기"
-        className="ml-2 shrink-0 w-7 h-7 grid place-items-center bg-transparent border-0 cursor-pointer rounded transition-colors hover:bg-pink-100"
+        className="absolute top-1/2 right-2 -translate-y-1/2 w-7 h-7 grid place-items-center bg-transparent border-0 cursor-pointer rounded transition-colors hover:bg-pink-100"
       >
         <svg
           className={`w-3 h-3 urwebs-star-icon ${isFavorited ? "favorited" : ""}`}


### PR DESCRIPTION
## Summary
- anchor WebsiteItem star button absolutely to the right to avoid covering titles
- add right padding to list item to reserve space for the star

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd632c16e0832e8f1d24f829259433