### PR TITLE
feat: add guest bookmark toolbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -55,3 +55,71 @@
   line-height: 1.4;
   color: var(--main-dark);
 }
+
+/* Toolbar & Ghost Buttons */
+.toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--btn-border, #e5e7eb);
+  background: var(--btn-bg, #fff);
+  color: var(--btn-fg, #111);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.02s;
+}
+.btn-ghost:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+.btn-ghost:active {
+  transform: translateY(1px);
+}
+.btn-ghost .hint {
+  margin-left: 6px;
+  opacity: 0.6;
+  font-size: 12px;
+}
+
+:root {
+  --btn-bg: #fff;
+  --btn-fg: #111;
+  --btn-border: #e5e7eb;
+}
+.dark {
+  --btn-bg: #121212;
+  --btn-fg: #f3f4f6;
+  --btn-border: #2a2a2a;
+}
+.dark .btn-ghost:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.btn-ghost svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+}
+
+.btn-group {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.btn-ghost.sm {
+  padding: 6px 10px;
+  font-size: 13px;
+}
+.btn-ghost.sm .hint {
+  font-size: 11px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { onSnapshot, writeBatch } from "firebase/firestore";
 import { getUserDocRef } from "./services/firestoreClient";
 import { stripUndefined } from "./utils/sanitize";
 import { assertAuthed } from "./utils/assert";
+import { setupGuestMigration } from "./services/bookmarks";
 
 import { Header } from "./components/Header";
 import { LoginModal } from "./components/LoginModal";
@@ -101,6 +102,10 @@ export default function App() {
 
   // ✅ 즐겨찾기 패널 오픈 상태 (오버레이)
   const [isFavOpen, setIsFavOpen] = useState(false);
+
+  useEffect(() => {
+    setupGuestMigration();
+  }, []);
 
   // ESC 로 패널 닫기
   useEffect(() => {

--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -13,6 +13,8 @@ import { trackVisit, buildFrequencyMap } from '../utils/visitTrack';
 import { sortByMode } from '../utils/sorters';
 import { toast } from 'sonner';
 import { Favicon } from './Favicon';
+import { GhostBtn, IconStarPlus, IconFolderPlus } from './ui/ghost-btn';
+import { saveBookmark } from '../services/bookmarks';
 
 interface FavoritesSectionProps {
   favoritesData: FavoritesData;
@@ -374,6 +376,22 @@ export function FavoritesSectionNew({
   const [draggedId, setDraggedId] = useState<string | null>(null);
   const [draggedFromFolderId, setDraggedFromFolderId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
+
+  function onAddFavorite() {
+    const title = document.title;
+    const url = window.location.href;
+    saveBookmark({ title, url, favicon: null, folderId: null })
+      .then((r) => {
+        if (r.mode === 'guest')
+          toast('로그인 없이 임시로 담았어요. 로그인하면 저장됩니다.');
+        else toast('즐겨찾기에 추가했어요!');
+      })
+      .catch(() => toast('저장 실패: 잠시 후 다시 시도해주세요.'));
+  }
+
+  function onAddFolder() {
+    setShowNewFolderInput(true);
+  }
 
   const handleDragStart = (e: React.DragEvent, id: string, fromFolderId?: string) => {
     setDraggedId(id);
@@ -758,6 +776,14 @@ export function FavoritesSectionNew({
       )}
 
       {/* 즐겨찾기 & 폴더 */}
+      <div className="toolbar btn-group mb-4">
+        <GhostBtn icon={<IconStarPlus />} hint="Ctrl+D" onClick={onAddFavorite}>
+          이 페이지를 즐겨찾기에 추가
+        </GhostBtn>
+        <GhostBtn icon={<IconFolderPlus />} onClick={onAddFolder}>
+          폴더 추가
+        </GhostBtn>
+      </div>
       <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-4 gap-y-6">
         {/* 즐겨찾기 리스트 */}
         <div className="col-span-1 space-y-2 lg:space-y-3 md:col-span-1 xl:col-span-1">

--- a/src/components/ui/ghost-btn.tsx
+++ b/src/components/ui/ghost-btn.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+export function IconStarPlus() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6L12 16l-4.9 2.3.9-5.6-4-3.9 5.5-.8L12 3z"
+        stroke="currentColor"
+      />
+      <path d="M18 6h4M20 4v4" stroke="currentColor" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function IconFolderPlus() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M3 7h6l2 2h10v8a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V7z"
+        stroke="currentColor"
+      />
+      <path d="M12 12h6M15 9v6" stroke="currentColor" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+type BtnProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  icon: React.ReactNode;
+  hint?: string;
+};
+
+export function GhostBtn({ icon, hint, children, ...rest }: BtnProps) {
+  return (
+    <button className="btn-ghost" {...rest}>
+      {icon}
+      <span>{children}</span>
+      {hint ? <span className="hint">{hint}</span> : null}
+    </button>
+  );
+}

--- a/src/services/bookmarks.ts
+++ b/src/services/bookmarks.ts
@@ -1,0 +1,55 @@
+import { doc, setDoc, serverTimestamp, writeBatch } from "firebase/firestore";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { db } from "../firebase";
+import { guestStore, Bookmark } from "./guestStore";
+import { stripUndefined } from "../utils/sanitize";
+
+export async function saveBookmark(input: Omit<Bookmark, "id">) {
+  const auth = getAuth();
+  const user = auth.currentUser;
+  if (!user) {
+    const id = crypto.randomUUID();
+    guestStore.add({ id, ...input });
+    return { mode: "guest", id } as const;
+  }
+  const id = crypto.randomUUID();
+  const ref = doc(db, "users", user.uid, "bookmarks", id);
+  const payload = stripUndefined({
+    title: input.title || "(제목 없음)",
+    url: input.url,
+    favicon: input.favicon ?? null,
+    folderId: input.folderId ?? null,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+  await setDoc(ref, payload, { merge: true });
+  return { mode: "authed", id } as const;
+}
+
+export function setupGuestMigration() {
+  const auth = getAuth();
+  onAuthStateChanged(auth, async (user) => {
+    if (!user) return;
+    const items = guestStore.list();
+    if (!items.length) return;
+    const batch = writeBatch(db);
+    items.forEach((bm) => {
+      const id = bm.id || crypto.randomUUID();
+      const ref = doc(db, "users", user.uid, "bookmarks", id);
+      batch.set(
+        ref,
+        stripUndefined({
+          title: bm.title || "(제목 없음)",
+          url: bm.url,
+          favicon: bm.favicon ?? null,
+          folderId: bm.folderId ?? null,
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        }),
+        { merge: true }
+      );
+    });
+    await batch.commit();
+    guestStore.clear();
+  });
+}

--- a/src/services/guestStore.ts
+++ b/src/services/guestStore.ts
@@ -1,0 +1,32 @@
+const LS_KEY = "urwebs_guest_bookmarks_v1";
+
+export type Bookmark = {
+  id: string;
+  title: string;
+  url: string;
+  favicon?: string | null;
+  folderId?: string | null;
+  createdAt?: number;
+  updatedAt?: number;
+};
+
+export const guestStore = {
+  list(): Bookmark[] {
+    try {
+      return JSON.parse(localStorage.getItem(LS_KEY) || "[]");
+    } catch {
+      return [];
+    }
+  },
+  add(bm: Bookmark) {
+    const now = Date.now();
+    const data = { ...bm, createdAt: now, updatedAt: now };
+    const items = guestStore.list();
+    items.unshift(data);
+    localStorage.setItem(LS_KEY, JSON.stringify(items.slice(0, 500)));
+    return data;
+  },
+  clear() {
+    localStorage.removeItem(LS_KEY);
+  },
+};


### PR DESCRIPTION
## Summary
- add ghost button styles and toolbar for favorites and folders
- allow saving bookmarks as guest and migrate to Firestore on login
- provide ghost button component with icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3cab3ee0832e81a0af8263613284