### PR TITLE
Persist guest favorites for unauthenticated sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,10 +162,21 @@ export default function App() {
           }
         );
       } else {
-        setFavoritesData(EMPTY_FAVORITES);
-        setCustomSites([]);
-        localStorage.removeItem(LS_KEYS.FAV);
-        localStorage.removeItem(LS_KEYS.CUSTOM);
+        try {
+          const rawFav = localStorage.getItem(LS_KEYS.FAV);
+          const favData = parseFavoritesData(
+            rawFav ? JSON.parse(rawFav) : undefined
+          );
+          const rawCustom = localStorage.getItem(LS_KEYS.CUSTOM);
+          const customData = parseCustomSites(
+            rawCustom ? JSON.parse(rawCustom) : undefined
+          );
+          setFavoritesData(favData);
+          setCustomSites(customData);
+        } catch {
+          setFavoritesData(EMPTY_FAVORITES);
+          setCustomSites([]);
+        }
         setAuthLoading(false);
       }
     });

--- a/src/hooks/useHasFavorites.ts
+++ b/src/hooks/useHasFavorites.ts
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 import { getAuth } from "firebase/auth";
 import { collection, getDocs, limit, query } from "firebase/firestore";
 import { db } from "../firebase";
+import { parseFavoritesData } from "../utils/validation";
+import { hasFavorites } from "../utils/fav";
+
+const LS_FAV = "urwebs-favorites-v3";
 
 export function useHasFavorites(uiMode: "discovery" | "collect") {
   const [hasFav, setHasFav] = useState<boolean>(false);
@@ -21,10 +25,10 @@ export function useHasFavorites(uiMode: "discovery" | "collect") {
 
       if (!user) {
         try {
-          const bm = JSON.parse(localStorage.getItem("urwebs_temp_bookmarks") || "[]");
-          const fd = JSON.parse(localStorage.getItem("urwebs_temp_folders") || "[]");
+          const raw = localStorage.getItem(LS_FAV);
+          const fav = parseFavoritesData(raw ? JSON.parse(raw) : undefined);
           if (!cancelled) {
-            setHasFav((bm?.length ?? 0) > 0 || (fd?.length ?? 0) > 0);
+            setHasFav(hasFavorites(fav.folders, fav.items));
           }
         } catch {
           if (!cancelled) setHasFav(false);


### PR DESCRIPTION
## Summary
- keep guest bookmarks and custom sites in localStorage when no user is signed in
- check localStorage for favorites when determining if guest data exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4e6754a4832eaa24fde84b8f6d66