### PR TITLE
Add description toggle for website listings

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -8,6 +8,8 @@ interface CategoryCardProps {
   config: CategoryConfig;
   favorites: string[];
   onToggleFavorite: (id: string) => void;
+  showDescriptions: boolean;
+  onToggleDescriptions: (v: boolean) => void;
 }
 
 export function CategoryCard({
@@ -16,6 +18,8 @@ export function CategoryCard({
   config,
   favorites,
   onToggleFavorite,
+  showDescriptions,
+  onToggleDescriptions,
 }: CategoryCardProps) {
   const safeSites = Array.isArray(sites) ? sites : [];
   const [visibleCount, setVisibleCount] = useState(6);
@@ -59,19 +63,35 @@ export function CategoryCard({
 
   return (
     <div className="urwebs-category-card h-full w-full min-w-0 rounded-xl border bg-white p-3 lg:p-4 flex flex-col shadow-sm dark:bg-gray-900">
-      <div className="flex items-center gap-3 px-3 py-4">
-        <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
-          {config.icon}
-        </span>
-        <span
-          style={{
-            fontSize: "1.1rem",
-            color: "var(--main-point)",
-            letterSpacing: "0.01em",
-          }}
+      <div className="flex items-center justify-between px-3 py-4">
+        <div className="flex items-center gap-3">
+          <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
+            {config.icon}
+          </span>
+          <span
+            style={{
+              fontSize: "1.1rem",
+              color: "var(--main-point)",
+              letterSpacing: "0.01em",
+            }}
+          >
+            {category}
+          </span>
+        </div>
+        <label
+          htmlFor="description-toggle"
+          className="urwebs-btn-ghost flex items-center gap-1 text-sm dark:text-gray-200 cursor-pointer"
+          data-guide="desc-toggle"
         >
-          {category}
-        </span>
+          <input
+            id="description-toggle"
+            type="checkbox"
+            checked={showDescriptions}
+            onChange={(e) => onToggleDescriptions(e.target.checked)}
+            className="mr-1"
+          />
+          사이트 설명 보기
+        </label>
       </div>
 
       {/* 사이트 목록 영역 */}
@@ -89,8 +109,9 @@ export function CategoryCard({
                   key={website.id}
                   website={website}
                   isDraggable={false}
-                  isFavorited={favorites.includes(website.id)}
+                  isFavorite={favorites.includes(website.id)}
                   onToggleFavorite={onToggleFavorite}
+                  showDescriptions={showDescriptions}
                 />
               ))}
               {loading &&

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -26,6 +26,7 @@ export function StartPage({
   // JSON에서 불러온 목록을 상태로 보관
   const [websites, setWebsites] = useState<Website[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showDescriptions, setShowDescriptions] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -198,6 +199,8 @@ export function StartPage({
                       config={categoryConfig[category]}
                       favorites={favoritesData.items}
                       onToggleFavorite={handleToggleFavorite}
+                      showDescriptions={showDescriptions}
+                      onToggleDescriptions={setShowDescriptions}
                     />
                   ))}
                 </div>

--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -5,18 +5,20 @@ import { Favicon } from "./Favicon";
 
 interface WebsiteItemProps {
   website: Website;
-  isFavorited: boolean;
+  isFavorite: boolean;
   onToggleFavorite: (id: string) => void;
   isDraggable?: boolean;
-  onDragStart: (e: React.DragEvent, website: Website) => void;
+  onDragStart?: (e: React.DragEvent, website: Website) => void;
+  showDescriptions: boolean;
 }
 
 export function WebsiteItem({
   website,
-  isFavorited,
+  isFavorite,
   onToggleFavorite,
   isDraggable = false,
   onDragStart,
+  showDescriptions,
 }: WebsiteItemProps) {
   if (!website?.url || !website?.title) return null;
 
@@ -28,7 +30,7 @@ export function WebsiteItem({
 
   const handleDragStart = (e: React.DragEvent) => {
     e.dataTransfer.setData("websiteId", website.id);
-    onDragStart(e, website);
+    onDragStart?.(e, website);
   };
 
   return (
@@ -43,7 +45,7 @@ export function WebsiteItem({
         className="favorite absolute top-1 right-1 w-5 h-5 grid place-items-center bg-transparent border-0 cursor-pointer rounded transition-colors hover:bg-pink-100"
       >
         <svg
-          className={`w-3 h-3 urwebs-star-icon ${isFavorited ? "favorited" : ""}`}
+          className={`w-3 h-3 urwebs-star-icon ${isFavorite ? "favorited" : ""}`}
           viewBox="0 0 24 24"
           strokeWidth="1"
         >
@@ -66,7 +68,7 @@ export function WebsiteItem({
             {website.title}
           </a>
 
-          {(website.summary || website.description) && (
+          {showDescriptions && (website.summary || website.description) && (
             <div className="mt-2 space-y-1">
               {website.summary && (
                 <div
@@ -78,21 +80,13 @@ export function WebsiteItem({
                     wordBreak: "break-word",
                   }}
                 >
-                  📝 {website.summary}
+                  {website.summary}
                 </div>
               )}
               {website.description && (
-                <div
-                  className="pl-1"
-                  style={{
-                    fontSize: "9px",
-                    color: "var(--sub-text)",
-                    lineHeight: 1.45,
-                    wordBreak: "break-word",
-                  }}
-                >
+                <p className="pl-1 text-xs leading-snug opacity-80">
                   {website.description}
-                </div>
+                </p>
               )}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Add `showDescriptions` toggle state in StartPage and pass through CategoryCard to WebsiteItem
- Display website summaries/descriptions only when toggle is enabled
- Clean up merge markers and update prop typings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be7f097660832ebc1e6c6c4f6c735f