### PR TITLE
Fix description toggle state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ export default function App() {
   });
   const [customSites, setCustomSites] = useState<CustomSite[]>([]);
   const [saving, setSaving] = useState(false);
+  const [showDescriptions, setShowDescriptions] = useState(false);
 
   // 기타 모달
   const [isContactModalOpen, setIsContactModalOpen] = useState(false);

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -8,8 +8,8 @@ interface CategoryCardProps {
   config: CategoryConfig;
   favorites: string[];
   onToggleFavorite: (id: string) => void;
-  showDescriptions: boolean;
-  onToggleDescriptions: (v: boolean) => void;
+  showDescriptions?: boolean;
+  onToggleDescriptions?: (v: boolean) => void;
 }
 
 export function CategoryCard({
@@ -18,8 +18,8 @@ export function CategoryCard({
   config,
   favorites,
   onToggleFavorite,
-  showDescriptions,
-  onToggleDescriptions,
+  showDescriptions = false,
+  onToggleDescriptions = () => {},
 }: CategoryCardProps) {
   const safeSites = Array.isArray(sites) ? sites : [];
   const [visibleCount, setVisibleCount] = useState(6);

--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -9,7 +9,7 @@ interface WebsiteItemProps {
   onToggleFavorite: (id: string) => void;
   isDraggable?: boolean;
   onDragStart?: (e: React.DragEvent, website: Website) => void;
-  showDescriptions: boolean;
+  showDescriptions?: boolean;
 }
 
 export function WebsiteItem({
@@ -18,7 +18,7 @@ export function WebsiteItem({
   onToggleFavorite,
   isDraggable = false,
   onDragStart,
-  showDescriptions,
+  showDescriptions = false,
 }: WebsiteItemProps) {
   if (!website?.url || !website?.title) return null;
 


### PR DESCRIPTION
## Summary
- manage showDescriptions state at the app level
- allow CategoryCard and WebsiteItem to accept optional showDescriptions props

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be82c409dc832ea26a05a121d43b3a