### PR TITLE
Remove site description toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,6 @@ export default function App() {
   });
   const [customSites, setCustomSites] = useState<CustomSite[]>([]);
   const [saving, setSaving] = useState(false);
-  const [showDescriptions, setShowDescriptions] = useState(false);
 
   // 기타 모달
   const [isContactModalOpen, setIsContactModalOpen] = useState(false);
@@ -420,8 +419,6 @@ export default function App() {
           onStartPageClick={handleStartPageClick}
           isDarkMode={isDarkMode}
           onToggleDarkMode={toggleDarkMode}
-          showDescriptions={showDescriptions}
-          onToggleDescriptions={() => setShowDescriptions((prev) => !prev)}
           // 로그인/회원가입 모달 열기
           onLoginClick={() => setIsLoginModalOpen(true)}
           onSignupClick={() => setIsSignupModalOpen(true)}

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -8,8 +8,6 @@ interface CategoryCardProps {
   config: CategoryConfig;
   favorites: string[];
   onToggleFavorite: (id: string) => void;
-  showDescriptions?: boolean;
-  onToggleDescriptions?: (v: boolean) => void;
 }
 
 export function CategoryCard({
@@ -18,8 +16,6 @@ export function CategoryCard({
   config,
   favorites,
   onToggleFavorite,
-  showDescriptions = false,
-  onToggleDescriptions = () => {},
 }: CategoryCardProps) {
   const safeSites = Array.isArray(sites) ? sites : [];
   const [visibleCount, setVisibleCount] = useState(6);
@@ -63,35 +59,19 @@ export function CategoryCard({
 
   return (
     <div className="urwebs-category-card h-full w-full min-w-0 rounded-xl border bg-white p-3 lg:p-4 flex flex-col shadow-sm dark:bg-gray-900">
-      <div className="flex items-center justify-between px-3 py-4">
-        <div className="flex items-center gap-3">
-          <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
-            {config.icon}
-          </span>
-          <span
-            style={{
-              fontSize: "1.1rem",
-              color: "var(--main-point)",
-              letterSpacing: "0.01em",
-            }}
-          >
-            {category}
-          </span>
-        </div>
-        <label
-          htmlFor="description-toggle"
-          className="urwebs-btn-ghost flex items-center gap-1 text-sm dark:text-gray-200 cursor-pointer"
-          data-guide="desc-toggle"
+      <div className="flex items-center gap-3 px-3 py-4">
+        <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
+          {config.icon}
+        </span>
+        <span
+          style={{
+            fontSize: "1.1rem",
+            color: "var(--main-point)",
+            letterSpacing: "0.01em",
+          }}
         >
-          <input
-            id="description-toggle"
-            type="checkbox"
-            checked={showDescriptions}
-            onChange={(e) => onToggleDescriptions(e.target.checked)}
-            className="mr-1"
-          />
-          사이트 설명 보기
-        </label>
+          {category}
+        </span>
       </div>
 
       {/* 사이트 목록 영역 */}
@@ -111,7 +91,6 @@ export function CategoryCard({
                   isDraggable={false}
                   isFavorite={favorites.includes(website.id)}
                   onToggleFavorite={onToggleFavorite}
-                  showDescriptions={showDescriptions}
                 />
               ))}
               {loading &&

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,8 +9,6 @@ interface HeaderProps {
   onStartPageClick: () => void;
   isDarkMode: boolean;
   onToggleDarkMode: () => void;
-  showDescriptions: boolean;
-  onToggleDescriptions: () => void;
   categoryTitle?: string;
   onLoginClick: () => void;
   onSignupClick: () => void;
@@ -25,8 +23,6 @@ export function Header({
   onStartPageClick,
   isDarkMode,
   onToggleDarkMode,
-  showDescriptions,
-  onToggleDescriptions,
   categoryTitle,
   onLoginClick,
   onSignupClick,
@@ -130,21 +126,6 @@ export function Header({
                 </button>
               </>
             )}
-            <label
-              htmlFor="description-toggle"
-              className="urwebs-btn-ghost flex items-center gap-1 text-sm dark:text-gray-200 cursor-pointer"
-              data-guide="desc-toggle"
-            >
-              <input
-                id="description-toggle"
-                type="checkbox"
-                checked={showDescriptions}
-                onChange={onToggleDescriptions}
-                className="mr-1"
-              />
-              사이트 설명 보기
-            </label>
-
             <button
               className="urwebs-btn-ghost flex items-center gap-2 text-sm dark:text-gray-200"
               onClick={onToggleDarkMode}

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -26,7 +26,6 @@ export function StartPage({
   // JSON에서 불러온 목록을 상태로 보관
   const [websites, setWebsites] = useState<Website[]>([]);
   const [loading, setLoading] = useState(true);
-  const [showDescriptions, setShowDescriptions] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -199,8 +198,6 @@ export function StartPage({
                       config={categoryConfig[category]}
                       favorites={favoritesData.items}
                       onToggleFavorite={handleToggleFavorite}
-                      showDescriptions={showDescriptions}
-                      onToggleDescriptions={setShowDescriptions}
                     />
                   ))}
                 </div>

--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -9,7 +9,6 @@ interface WebsiteItemProps {
   onToggleFavorite: (id: string) => void;
   isDraggable?: boolean;
   onDragStart?: (e: React.DragEvent, website: Website) => void;
-  showDescriptions?: boolean;
 }
 
 export function WebsiteItem({
@@ -18,7 +17,6 @@ export function WebsiteItem({
   onToggleFavorite,
   isDraggable = false,
   onDragStart,
-  showDescriptions = false,
 }: WebsiteItemProps) {
   if (!website?.url || !website?.title) return null;
 
@@ -33,65 +31,42 @@ export function WebsiteItem({
     onDragStart?.(e, website);
   };
 
+  const summaryOrDesc = website.summary || website.description;
+
   return (
     <li
-      className="urwebs-website-item relative flex items-center min-h-9 rounded-md min-w-0 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
+      className="urwebs-website-item relative px-2 py-2 rounded-md hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
       draggable={isDraggable}
       onDragStart={handleDragStart}
     >
-      <button
-        onClick={handleFavoriteClick}
-        aria-label="즐겨찾기"
-        className="favorite absolute top-1 right-1 w-5 h-5 grid place-items-center bg-transparent border-0 cursor-pointer rounded transition-colors hover:bg-pink-100"
-      >
-        <svg
-          className={`w-3 h-3 urwebs-star-icon ${isFavorite ? "favorited" : ""}`}
-          viewBox="0 0 24 24"
-          strokeWidth="1"
-        >
-          <polygon points="12,2 15,8 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8"></polygon>
-        </svg>
-      </button>
-
-      <div className="left flex items-center gap-2 min-w-0 flex-1">
+      <div className="flex items-center gap-2 min-w-0">
         <Favicon domain={website.url} className="w-4 h-4 rounded border shrink-0" />
-        <div className="min-w-0 flex-1 pr-2">
-          <a
-            href={website.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block truncate text-[var(--main-dark)] focus:outline-none"
-            style={{ fontSize: "12.5px" }}
-            title={website.title}
-            onClick={() => trackVisit(website.id)}
-          >
-            {website.title}
-          </a>
-
-          {showDescriptions && (website.summary || website.description) && (
-            <div className="mt-2 space-y-1">
-              {website.summary && (
-                <div
-                  className="pl-1 font-medium"
-                  style={{
-                    fontSize: "10px",
-                    color: "var(--sub-text)",
-                    lineHeight: 1.4,
-                    wordBreak: "break-word",
-                  }}
-                >
-                  {website.summary}
-                </div>
-              )}
-              {website.description && (
-                <p className="pl-1 text-xs leading-snug opacity-80">
-                  {website.description}
-                </p>
-              )}
-            </div>
-          )}
-        </div>
+        <a
+          href={website.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block truncate text-[var(--main-dark)] focus:outline-none pr-8 min-w-0 flex-1"
+          title={website.title}
+          onClick={() => trackVisit(website.id)}
+        >
+          {website.title}
+        </a>
+        <button
+          onClick={handleFavoriteClick}
+          aria-label="즐겨찾기"
+          className="favorite absolute top-2 right-2 grid place-items-center w-5 h-5 bg-transparent border-0 cursor-pointer rounded hover:bg-pink-100"
+        >
+          <svg className={`w-3 h-3 urwebs-star-icon ${isFavorite ? "favorited" : ""}`} viewBox="0 0 24 24" strokeWidth="1">
+            <polygon points="12,2 15,8.2 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8.2" />
+          </svg>
+        </button>
       </div>
+
+      {summaryOrDesc && (
+        <div className="mt-1 text-xs leading-snug opacity-80 pl-6">
+          {website.summary ?? website.description}
+        </div>
+      )}
     </li>
   );
 }


### PR DESCRIPTION
## Summary
- remove all showDescriptions state/props and description toggle UI
- always render website summary or description on a second line

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be880ecc64832ebc87bf081e1bfd7c