### PR TITLE
feat: refine website card layout

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -31,8 +31,6 @@ export function WebsiteItem({
     onDragStart?.(e, website);
   };
 
-  const summaryOrDesc = website.summary || website.description;
-
   return (
     <li
       className="urwebs-website-item relative px-2 py-2 rounded-md hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
@@ -41,31 +39,37 @@ export function WebsiteItem({
     >
       <div className="flex items-center gap-2 min-w-0">
         <Favicon domain={website.url} className="w-4 h-4 rounded border shrink-0" />
+
         <a
           href={website.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="block truncate text-[var(--main-dark)] focus:outline-none pr-8 min-w-0 flex-1"
+          className="block font-medium truncate text-sm text-[var(--main-dark)] focus:outline-none pr-8 flex-1"
           title={website.title}
           onClick={() => trackVisit(website.id)}
         >
           {website.title}
         </a>
+
         <button
           onClick={handleFavoriteClick}
           aria-label="즐겨찾기"
           className="favorite absolute top-2 right-2 grid place-items-center w-5 h-5 bg-transparent border-0 cursor-pointer rounded hover:bg-pink-100"
         >
-          <svg className={`w-3 h-3 urwebs-star-icon ${isFavorite ? "favorited" : ""}`} viewBox="0 0 24 24" strokeWidth="1">
+          <svg
+            className={`w-3 h-3 urwebs-star-icon ${isFavorite ? "favorited" : ""}`}
+            viewBox="0 0 24 24"
+            strokeWidth="1"
+          >
             <polygon points="12,2 15,8.2 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8.2" />
           </svg>
         </button>
       </div>
 
-      {summaryOrDesc && (
-        <div className="mt-1 text-xs leading-snug opacity-80 pl-6">
+      {(website.summary || website.description) && (
+        <p className="mt-1 text-xs leading-snug text-gray-600 dark:text-gray-300 pl-6 line-clamp-2">
           {website.summary ?? website.description}
-        </div>
+        </p>
       )}
     </li>
   );


### PR DESCRIPTION
## Summary
- enforce single-line truncated title with stronger styling
- show description in up to two lines with smaller font
- keep favorite button positioned in top-right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be8b5a15a0832e89905d13e0bca988