### PR TITLE
refactor: use grid layout for website item

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -33,41 +33,39 @@ export function WebsiteItem({
 
   return (
     <li
-      className="urwebs-website-item px-2 py-2 rounded-md hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
+      className="urwebs-website-item grid grid-cols-[20px,1fr,24px] gap-x-2 gap-y-1 items-center px-2 py-2 rounded-md hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
       draggable={isDraggable}
       onDragStart={handleDragStart}
     >
-      <div className="flex items-center gap-2 min-w-0">
-        <Favicon domain={website.url} className="w-4 h-4 rounded border shrink-0" />
+      <Favicon domain={website.url} className="w-4 h-4 rounded border shrink-0" />
 
-        <a
-          href={website.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-sm text-[var(--main-dark)] focus:outline-none flex-1 min-w-[8ch] truncate"
-          title={website.title}
-          onClick={() => trackVisit(website.id)}
-        >
-          {website.title}
-        </a>
+      <a
+        href={website.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block w-full font-medium text-sm text-[var(--main-dark)] focus:outline-none min-w-[10ch] truncate"
+        title={website.title}
+        onClick={() => trackVisit(website.id)}
+      >
+        {website.title}
+      </a>
 
-        <button
-          onClick={handleFavoriteClick}
-          aria-label="즐겨찾기"
-          className="favorite grid place-items-center w-5 h-5 bg-transparent border-0 cursor-pointer rounded hover:bg-pink-100 shrink-0"
+      <button
+        onClick={handleFavoriteClick}
+        aria-label="즐겨찾기"
+        className="favorite grid place-items-center w-5 h-5 bg-transparent border-0 cursor-pointer rounded hover:bg-pink-100 shrink-0"
+      >
+        <svg
+          className={`w-3 h-3 urwebs-star-icon ${isFavorite ? "favorited" : ""}`}
+          viewBox="0 0 24 24"
+          strokeWidth="1"
         >
-          <svg
-            className={`w-3 h-3 urwebs-star-icon ${isFavorite ? "favorited" : ""}`}
-            viewBox="0 0 24 24"
-            strokeWidth="1"
-          >
-            <polygon points="12,2 15,8.2 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8.2" />
-          </svg>
-        </button>
-      </div>
+          <polygon points="12,2 15,8.2 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8.2" />
+        </svg>
+      </button>
 
       {(website.summary || website.description) && (
-        <p className="mt-1 ml-6 text-xs leading-snug text-gray-600 dark:text-gray-300 line-clamp-2">
+        <p className="col-start-2 col-span-2 text-xs leading-snug text-gray-600 dark:text-gray-300 line-clamp-2">
           {website.summary ?? website.description}
         </p>
       )}


### PR DESCRIPTION
## Summary
- refactor WebsiteItem layout into 3-column grid to separate icon, title, and favorite star
- ensure title reserves space for ~10 characters before truncating
- show description on its own row spanning remaining columns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9778a424832e9a56a26662753687