### PR TITLE
Ensure website titles display up to eight characters

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -43,11 +43,11 @@ export function WebsiteItem({
         href={website.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="block w-full font-medium text-sm text-[var(--main-dark)] focus:outline-none min-w-[10ch] truncate"
+        className="block w-full font-medium text-sm text-[var(--main-dark)] focus:outline-none min-w-[8ch] truncate"
         title={website.title}
         onClick={() => trackVisit(website.id)}
       >
-        {website.title}
+        {website.title.slice(0, 8)}
       </a>
 
       <button


### PR DESCRIPTION
## Summary
- Limit website title render length to eight characters and adjust minimum width accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9a63bd7c832e9094d6355c1dd7a9