### PR TITLE
Fix WebsiteItem grid layout and text contrast

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -33,42 +33,47 @@ export function WebsiteItem({
 
   return (
     <li
-      className="urwebs-website-item grid grid-cols-[20px,1fr,24px] gap-x-2 gap-y-1 items-center px-2 py-2 rounded-md hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
+      className="urwebs-website-item px-2 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-800 focus-within:ring-2 focus-within:ring-blue-400"
       draggable={isDraggable}
       onDragStart={handleDragStart}
     >
-      <Favicon domain={website.url} className="w-4 h-4 rounded border shrink-0" />
+      <div className="grid grid-cols-[20px_1fr_24px] items-start gap-x-2 min-w-0">
+        <Favicon
+          domain={website.url}
+          className="w-5 h-5 rounded border col-start-1 row-start-1 justify-self-start self-center"
+        />
 
-      <a
-        href={website.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block w-full font-medium text-sm text-[var(--main-dark)] focus:outline-none min-w-[8ch] truncate"
-        title={website.title}
-        onClick={() => trackVisit(website.id)}
-      >
-        {website.title.slice(0, 8)}
-      </a>
-
-      <button
-        onClick={handleFavoriteClick}
-        aria-label="즐겨찾기"
-        className="favorite grid place-items-center w-5 h-5 bg-transparent border-0 cursor-pointer rounded hover:bg-pink-100 shrink-0"
-      >
-        <svg
-          className={`w-3 h-3 urwebs-star-icon ${isFavorite ? "favorited" : ""}`}
-          viewBox="0 0 24 24"
-          strokeWidth="1"
+        <a
+          href={website.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={website.title}
+          onClick={() => trackVisit(website.id)}
+          className="col-start-2 row-start-1 block font-medium text-sm text-zinc-900 dark:text-zinc-100 min-w-0 truncate [min-width:10ch] focus:outline-none"
         >
-          <polygon points="12,2 15,8.2 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8.2" />
-        </svg>
-      </button>
+          {website.title}
+        </a>
 
-      {(website.summary || website.description) && (
-        <p className="col-start-2 col-span-2 text-xs leading-snug text-gray-600 dark:text-gray-300 line-clamp-2">
-          {website.summary ?? website.description}
-        </p>
-      )}
+        <button
+          onClick={handleFavoriteClick}
+          aria-label="즐겨찾기"
+          className="col-start-3 row-start-1 justify-self-end self-start w-6 h-6 grid place-items-center rounded hover:bg-pink-100 dark:hover:bg-zinc-700"
+        >
+          <svg
+            className={`w-4 h-4 urwebs-star-icon ${isFavorite ? "favorited" : ""}`}
+            viewBox="0 0 24 24"
+            strokeWidth="1"
+          >
+            <polygon points="12,2 15,8.2 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8.2" />
+          </svg>
+        </button>
+
+        {(website.summary || website.description) && (
+          <p className="col-start-2 col-span-2 row-start-2 mt-1 text-xs leading-snug text-zinc-700 dark:text-zinc-300 min-w-0 line-clamp-2">
+            {website.summary ?? website.description}
+          </p>
+        )}
+      </div>
     </li>
   );
 }


### PR DESCRIPTION
## Summary
- use Tailwind-friendly grid syntax and move layout into inner div
- improve dark mode text colors and prevent title/description clipping
- ensure description shows up to two lines with line clamp

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bed1eb8224832ebadf7c474c50ce7c