### PR TITLE
Fix missing category titles

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -60,7 +60,10 @@ export function CategoryCard({
   return (
     <div className="urwebs-category-card h-full w-full min-w-0 rounded-xl border bg-white p-3 lg:p-4 flex flex-col shadow-sm dark:bg-gray-900">
       <div className="flex items-center gap-3 px-3 py-4">
-        <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
+        <span
+          style={{ fontSize: "0.9rem" }}
+          className={`flex-shrink-0 ${config.iconClass}`}
+        >
           {config.icon}
         </span>
         <span
@@ -70,7 +73,7 @@ export function CategoryCard({
             letterSpacing: "0.01em",
           }}
         >
-          {category}
+          {config.title ?? category}
         </span>
       </div>
 

--- a/src/data/websites.ts
+++ b/src/data/websites.ts
@@ -139,7 +139,7 @@ export const categoryConfig = {
   "건축가": { title: "건축가", icon: "👨‍💼", iconClass: "icon-purple" },
   "포털사이트": { title: "포털사이트", icon: "🌐", iconClass: "icon-orange" },
   "기타": { title: "기타", icon: "📚", iconClass: "icon-gray" },
-  "자료" : { title: "기타", icon: "📚", iconClass: "icon-gray" },
+  "자료": { title: "자료", icon: "📚", iconClass: "icon-gray" },
 };
 
 export const categoryOrder = [


### PR DESCRIPTION
## Summary
- show category titles using configured labels and icon classes
- correct mislabeled "자료" category config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bed3a1b86c832e97a34baa08b192ac