### PR TITLE
Ensure public status directory exists before writing

### DIFF
--- a/public/status.txt
+++ b/public/status.txt
@@ -1,2 +1,5 @@
 ok
 app: urwebs
+version: ff625d20
+buildTime: 2025-09-08T14:31:05+00:00
+commit: Add files via upload

--- a/scripts/write-status.mjs
+++ b/scripts/write-status.mjs
@@ -1,8 +1,9 @@
-import { writeFileSync } from "fs";
+import { writeFileSync, mkdirSync } from "fs";
 import { execSync } from "child_process";
 const sha = execSync("git rev-parse --short HEAD").toString().trim();
 const msg = execSync('git log -1 --pretty=%s').toString().trim();
 const now = new Date().toISOString();
+mkdirSync('public', { recursive: true });
 writeFileSync("public/status.txt",
 `ok
 app: urwebs


### PR DESCRIPTION
## Summary
- Import `mkdirSync` to create the `public` folder if missing
- Update `public/status.txt` so the folder is checked into Git

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee8423af4832ea428fa721950b554