### PR TITLE
Expand category site boxes and left-align descriptions

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -63,7 +63,7 @@ export function CategoryCard({
 
   return (
     <div className="urwebs-category-card h-full w-full min-w-0 rounded-xl border bg-white p-3 lg:p-4 flex flex-col shadow-sm dark:bg-gray-900">
-      <div className="flex items-center gap-3 px-3 py-4">
+      <div className="flex items-center gap-3 px-3 py-2">
         <span style={{ fontSize: "0.9rem" }} className="flex-shrink-0">
           {config.icon}
         </span>

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -189,7 +189,7 @@ export function StartPage({
                 <div
                   className="grid gap-x-4 gap-y-6"
                   style={{
-                    gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
                   }}
                 >
                   {categoryOrder.map((category) => (

--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -35,7 +35,7 @@ export function WebsiteItem({
 
   return (
     <li
-      className="urwebs-website-item relative flex flex-col min-h-9 rounded-md min-w-0 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
+      className="urwebs-website-item relative flex flex-col items-start min-h-9 rounded-md min-w-0 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
       style={{ height: showDescription ? "auto" : undefined }}
       draggable={isDraggable}
       onDragStart={handleDragStart}
@@ -74,7 +74,7 @@ export function WebsiteItem({
 
       {showDescription && (website.summary || website.description) && (
         <div
-          className="mt-1 pl-6 pr-2"
+          className="mt-1 pl-6 pr-2 text-left"
           style={{
             fontSize: "10px",
             color: "var(--sub-text)",


### PR DESCRIPTION
## Summary
- widen category site grid to allow site boxes 1.2x wider
- align website descriptions to the left for clearer reading
- halve top spacing above category titles for a tighter layout

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beea05a9f8832ea46e929a0c8ecafa