### PR TITLE
chore: tighten card spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -490,7 +490,7 @@ export default function App() {
                 {/* ✅ 메인: 카테고리 그리드 (항상 첫 화면에 보이게) */}
                 <section className="mt-6 w-full overflow-x-hidden">
                   <div className="mx-auto w-full max-w-[1180px] px-4 sm:px-5 lg:px-6">
-                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-5 gap-x-4 gap-y-6 min-w-0">
+                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-5 gap-x-2 gap-y-4 min-w-0">
                       {categoryOrder.map((category) => (
                         <CategoryCard
                           key={category}

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -187,7 +187,7 @@ export function StartPage({
               <div>
                 <h2 className="text-2xl font-bold text-gray-800 mb-6">전체 카테고리</h2>
                 <div
-                  className="grid gap-x-4 gap-y-6"
+                  className="grid gap-x-2 gap-y-4"
                   style={{
                     gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
                   }}

--- a/src/index.css
+++ b/src/index.css
@@ -5177,7 +5177,7 @@ html {
   transition: border-color .14s, box-shadow .1s;
   display: flex;
   align-items: center;
-  padding: 6px 26px 6px 10px;
+  padding: 4px 18px 4px 8px;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- reduce gaps between category cards
- shrink website item padding for tighter cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf73159618832ea40f738b2514d585