### PR TITLE
Expand website item cards to full width

### DIFF
--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -35,7 +35,7 @@ export function WebsiteItem({
 
   return (
     <li
-      className="urwebs-website-item relative flex flex-col items-start min-h-9 rounded-md min-w-0 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
+      className="urwebs-website-item relative flex w-full flex-col items-start min-h-9 rounded-md min-w-0 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
       style={{ height: showDescription ? "auto" : undefined }}
       draggable={isDraggable}
       onDragStart={handleDragStart}

--- a/src/index.css
+++ b/src/index.css
@@ -5177,6 +5177,7 @@ html {
   transition: border-color .14s, box-shadow .1s;
   display: flex;
   align-items: center;
+  width: 100%;
   padding: 4px 18px 4px 8px;
   position: relative;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -260,6 +260,7 @@ html {
   transition: border-color 0.14s, box-shadow 0.1s;
   display: flex;
   align-items: center;
+  width: 100%;
   padding: 6px 26px 6px 10px;
   position: relative;
 }


### PR DESCRIPTION
## Summary
- Ensure website items stretch across their container by applying `w-full`
- Update global styles so `.urwebs-website-item` uses `width:100%`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf74f9593c832e9dd26d2d8ff9f9e4