### PR TITLE
feat: add default folder structure to starter pack

### DIFF
--- a/src/data/starter.json
+++ b/src/data/starter.json
@@ -1,5 +1,10 @@
 {
-  "favorites": ["60", "62", "12"],
+  "favorites": [],
+  "folders": [
+    { "id": "f-design", "name": "디자인", "items": ["60"] },
+    { "id": "f-contest", "name": "공모전", "items": ["62"] },
+    { "id": "f-jobs", "name": "채용정보", "items": ["12"] }
+  ],
   "widgets": [
     { "id": "w-weather", "type": "weather" },
     { "id": "w-clock", "type": "clock" }

--- a/src/utils/startPageStorage.ts
+++ b/src/utils/startPageStorage.ts
@@ -1,10 +1,19 @@
-import { FavoritesData, Widget } from '../types';
+import { FavoritesData, Widget, SortMode } from '../types';
 import starter from '../data/starter.json';
 
 const STORAGE_KEY = 'urwebs-favorites-v3';
 
+interface StarterFolder {
+  id: string;
+  name: string;
+  items: string[];
+  color?: string;
+  sortMode?: SortMode;
+}
+
 interface StarterRaw {
   favorites: string[];
+  folders?: StarterFolder[];
   widgets: { id: string; type: Widget['type'] }[];
 }
 
@@ -33,7 +42,14 @@ function buildStarter(): FavoritesData {
     id: w.id,
     type: w.type,
   }));
-  return { items: starterData.favorites || [], folders: [], widgets };
+  const folders = (starterData.folders || []).map((f) => ({
+    id: f.id,
+    name: f.name,
+    items: f.items || [],
+    color: f.color,
+    sortMode: f.sortMode,
+  }));
+  return { items: starterData.favorites || [], folders, widgets };
 }
 
 export function applyStarter(onUpdate: (data: FavoritesData) => void) {


### PR DESCRIPTION
## Summary
- seed starter pack with recommended folders, bookmarks, and widgets
- load starter folders from config when applying starter pack

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c009199410832e8c3ee9386924b294