### PR TITLE
feat: add default folder structure to starter pack

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import "./App.css";
 import { applyPreset } from "./utils/applyPreset";
 import { toggleFavorite as toggleFavoriteData } from "./utils/favorites";
 import { parseFavoritesData, parseCustomSites } from "./utils/validation";
+import { getStarterData } from "./utils/startPageStorage";
 import { Skeleton } from "./components/ui/skeleton";
 import { useUIMode } from "./hooks/useUIMode";
 import { hasFavorites } from "./utils/fav";
@@ -159,9 +160,17 @@ export default function App() {
       } else {
         try {
           const rawFav = localStorage.getItem(LS_KEYS.FAV);
-          const favData = parseFavoritesData(
+          let favData = parseFavoritesData(
             rawFav ? JSON.parse(rawFav) : undefined
           );
+          if (
+            favData.items.length === 0 &&
+            favData.folders.length === 0 &&
+            favData.widgets.length === 0
+          ) {
+            favData = getStarterData();
+            localStorage.setItem(LS_KEYS.FAV, JSON.stringify(favData));
+          }
           const rawCustom = localStorage.getItem(LS_KEYS.CUSTOM);
           const customData = parseCustomSites(
             rawCustom ? JSON.parse(rawCustom) : undefined

--- a/src/data/starter.json
+++ b/src/data/starter.json
@@ -1,5 +1,10 @@
 {
-  "favorites": ["60", "62", "12"],
+  "favorites": [],
+  "folders": [
+    { "id": "f-design", "name": "디자인", "items": ["60"] },
+    { "id": "f-contest", "name": "공모전", "items": ["62"] },
+    { "id": "f-jobs", "name": "채용정보", "items": ["12"] }
+  ],
   "widgets": [
     { "id": "w-weather", "type": "weather" },
     { "id": "w-clock", "type": "clock" }

--- a/src/utils/startPageStorage.ts
+++ b/src/utils/startPageStorage.ts
@@ -1,10 +1,19 @@
-import { FavoritesData, Widget } from '../types';
+import { FavoritesData, Widget, SortMode } from '../types';
 import starter from '../data/starter.json';
 
 const STORAGE_KEY = 'urwebs-favorites-v3';
 
+interface StarterFolder {
+  id: string;
+  name: string;
+  items: string[];
+  color?: string;
+  sortMode?: SortMode;
+}
+
 interface StarterRaw {
   favorites: string[];
+  folders?: StarterFolder[];
   widgets: { id: string; type: Widget['type'] }[];
 }
 
@@ -28,16 +37,23 @@ export function saveFavoritesData(data: FavoritesData) {
   }
 }
 
-function buildStarter(): FavoritesData {
+export function getStarterData(): FavoritesData {
   const widgets: Widget[] = (starterData.widgets || []).map((w) => ({
     id: w.id,
     type: w.type,
   }));
-  return { items: starterData.favorites || [], folders: [], widgets };
+  const folders = (starterData.folders || []).map((f) => ({
+    id: f.id,
+    name: f.name,
+    items: f.items || [],
+    color: f.color,
+    sortMode: f.sortMode,
+  }));
+  return { items: starterData.favorites || [], folders, widgets };
 }
 
 export function applyStarter(onUpdate: (data: FavoritesData) => void) {
-  const data = buildStarter();
+  const data = getStarterData();
   saveFavoritesData(data);
   onUpdate(data);
 }


### PR DESCRIPTION
## Summary
- expose starter pack builder and reuse it when applying starter data
- auto-load starter pack when a user has no saved favorites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c009199410832e8c3ee9386924b294