### PR TITLE
feat: add landing and domain pages with routing

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,24 +1,34 @@
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import { Toaster } from "sonner";
-import App from "./App";
+import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import BoardList from "./pages/BoardList";
 import PostDetail from "./pages/PostDetail";
 import PostWrite from "./pages/PostWrite";
-import { AppErrorBoundary } from "./components/AppErrorBoundary";
+import MainLanding from "./pages/MainLanding";
+import ArchitectureHome from "./pages/ArchitectureHome";
+import RealEstateHome from "./pages/RealEstateHome";
+import StocksHome from "./pages/StocksHome";
+import StartPageWrapper from "./pages/StartPageWrapper";
 
 export default function Root() {
   return (
     <AppErrorBoundary>
       <>
         <Routes>
-          <Route path="/" element={<App />} />
+          <Route path="/" element={<MainLanding />} />
+          <Route path="/architecture" element={<ArchitectureHome />} />
+          <Route path="/realestate" element={<RealEstateHome />} />
+          <Route path="/stocks" element={<StocksHome />} />
+          <Route path="/start" element={<StartPageWrapper />} />
           <Route path="/notice" element={<BoardList board="notice" />} />
           <Route path="/free" element={<BoardList board="free" />} />
           <Route path="/post/:id" element={<PostDetail />} />
           <Route path="/write" element={<PostWrite />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
         <Toaster position="top-center" />
       </>
     </AppErrorBoundary>
   );
 }
+

--- a/src/pages/ArchitectureHome.tsx
+++ b/src/pages/ArchitectureHome.tsx
@@ -1,0 +1,35 @@
+import { Link } from "react-router-dom";
+
+export default function ArchitectureHome() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6">
+      <div className="mx-auto max-w-2xl">
+        <Link to="/" className="text-blue-600 hover:underline">
+          &larr; 메인
+        </Link>
+        <h1 className="mb-8 mt-4 text-3xl font-bold">건축학과</h1>
+        <div className="space-y-4">
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">자료</h2>
+            <p className="text-sm text-gray-600">
+              건축 학생을 위한 자료가 모일 예정입니다.
+            </p>
+          </section>
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">사이트</h2>
+            <p className="text-sm text-gray-600">
+              유용한 사이트 링크들을 준비합니다.
+            </p>
+          </section>
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">도구</h2>
+            <p className="text-sm text-gray-600">
+              학습과 설계에 도움이 되는 도구를 소개할 예정입니다.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/pages/MainLanding.tsx
+++ b/src/pages/MainLanding.tsx
@@ -1,0 +1,33 @@
+import { Link } from "react-router-dom";
+
+export default function MainLanding() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center gap-8 p-4 text-center">
+      <h1 className="text-3xl font-bold">서비스 선택</h1>
+      <div className="flex w-full max-w-xs flex-col gap-4">
+        <Link
+          to="/architecture"
+          className="rounded border bg-white px-6 py-3 text-lg shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          건축학과
+        </Link>
+        <Link
+          to="/realestate"
+          className="rounded border bg-white px-6 py-3 text-lg shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          부동산
+        </Link>
+        <Link
+          to="/stocks"
+          className="rounded border bg-white px-6 py-3 text-lg shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          증권
+        </Link>
+      </div>
+      <Link to="/start" className="mt-8 text-sm text-blue-600 underline">
+        나의 시작페이지로 이동
+      </Link>
+    </main>
+  );
+}
+

--- a/src/pages/RealEstateHome.tsx
+++ b/src/pages/RealEstateHome.tsx
@@ -1,0 +1,35 @@
+import { Link } from "react-router-dom";
+
+export default function RealEstateHome() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6">
+      <div className="mx-auto max-w-2xl">
+        <Link to="/" className="text-blue-600 hover:underline">
+          &larr; 메인
+        </Link>
+        <h1 className="mb-8 mt-4 text-3xl font-bold">부동산</h1>
+        <div className="space-y-4">
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">매물/시세</h2>
+            <p className="text-sm text-gray-600">
+              부동산 매물과 시세 정보를 확인합니다.
+            </p>
+          </section>
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">지도/입지</h2>
+            <p className="text-sm text-gray-600">
+              위치와 주변 환경을 살펴봅니다.
+            </p>
+          </section>
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">정책/뉴스</h2>
+            <p className="text-sm text-gray-600">
+              부동산 관련 정책과 뉴스를 모아봅니다.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/pages/StartPageWrapper.tsx
+++ b/src/pages/StartPageWrapper.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { StartPage } from "../components/StartPage";
+import type { FavoritesData } from "../types";
+import { loadFavoritesData } from "../utils/startPageStorage";
+
+export default function StartPageWrapper() {
+  const navigate = useNavigate();
+  const [favoritesData, setFavoritesData] = useState<FavoritesData>(() =>
+    loadFavoritesData()
+  );
+
+  return (
+    <StartPage
+      favoritesData={favoritesData}
+      onUpdateFavorites={setFavoritesData}
+      onClose={() => navigate("/")}
+      showDescriptions={true}
+    />
+  );
+}
+

--- a/src/pages/StocksHome.tsx
+++ b/src/pages/StocksHome.tsx
@@ -1,0 +1,35 @@
+import { Link } from "react-router-dom";
+
+export default function StocksHome() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6">
+      <div className="mx-auto max-w-2xl">
+        <Link to="/" className="text-blue-600 hover:underline">
+          &larr; 메인
+        </Link>
+        <h1 className="mb-8 mt-4 text-3xl font-bold">증권</h1>
+        <div className="space-y-4">
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">관심 종목</h2>
+            <p className="text-sm text-gray-600">
+              추적 중인 종목을 관리합니다.
+            </p>
+          </section>
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">시장 요약</h2>
+            <p className="text-sm text-gray-600">
+              주요 지수와 시장 흐름을 확인합니다.
+            </p>
+          </section>
+          <section className="rounded bg-white p-4 shadow">
+            <h2 className="mb-2 font-semibold">학습/전략</h2>
+            <p className="text-sm text-gray-600">
+              투자 학습 자료와 전략을 모읍니다.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add minimal main landing with links to architecture, real estate, stocks
- create placeholder pages for each domain and StartPage wrapper
- route new pages and redirect unknown paths to main landing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c115c3ea8c832e8305acb8593f20a5