### PR TITLE
feat: add expandable main page with category grid

### DIFF
--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -1,0 +1,24 @@
+import type { FieldCategory } from "../types";
+
+export const categories: FieldCategory[] = [
+  {
+    slug: 'architecture',
+    title: '건축학과',
+    emoji: '🏛️',
+    description: '건축 정보를 모았습니다',
+  },
+  {
+    slug: 'realestate',
+    title: '부동산',
+    emoji: '🏠',
+    description: '부동산 관련 자료를 빠르게',
+  },
+  {
+    slug: 'stocks',
+    title: '증권',
+    emoji: '📈',
+    description: '투자와 주식 정보를 확인',
+  },
+];
+
+export default categories;

--- a/src/pages/MainLanding.tsx
+++ b/src/pages/MainLanding.tsx
@@ -1,33 +1,58 @@
 import { Link } from "react-router-dom";
+import categoriesData from "../data/categories";
 
 export default function MainLanding() {
+  const categories = [...categoriesData].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0)
+  );
+
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center gap-8 p-4 text-center">
-      <h1 className="text-3xl font-bold">서비스 선택</h1>
-      <div className="flex w-full max-w-xs flex-col gap-4">
-        <Link
-          to="/architecture"
-          className="rounded border bg-white px-6 py-3 text-lg shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          건축학과
-        </Link>
-        <Link
-          to="/realestate"
-          className="rounded border bg-white px-6 py-3 text-lg shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          부동산
-        </Link>
-        <Link
-          to="/stocks"
-          className="rounded border bg-white px-6 py-3 text-lg shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          증권
-        </Link>
-      </div>
-      <Link to="/start" className="mt-8 text-sm text-blue-600 underline">
-        나의 시작페이지로 이동
-      </Link>
+    <main className="min-h-screen flex flex-col">
+      <section className="flex flex-col-reverse items-center gap-8 px-4 pt-12 pb-8 md:flex-row md:gap-12 md:pt-24 md:pb-16">
+        <div className="text-center md:text-left md:flex-1">
+          <h1 className="text-4xl font-bold">URWEBS</h1>
+          <p className="mt-2 text-lg text-gray-700">분야별로 빠르게 시작하세요</p>
+          <Link to="/start" className="mt-4 inline-block text-sm text-blue-600 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
+            나의 시작페이지로 이동
+          </Link>
+        </div>
+        <figure className="w-full md:flex-1">
+          <img
+            src="/assets/favorites-sample.webp"
+            alt="즐겨찾기 예시 레이아웃 스크린샷"
+            loading="lazy"
+            width={1280}
+            height={720}
+            srcSet="/assets/favorites-sample.webp 1280w, /assets/favorites-sample.webp 640w"
+            sizes="(max-width: 768px) 100vw, 50vw"
+            className="w-full h-auto rounded-lg shadow"
+          />
+          <figcaption className="mt-2 text-xs text-gray-500 text-center md:text-right">
+            즐겨찾기를 이렇게 정리할 수 있어요
+          </figcaption>
+        </figure>
+      </section>
+      <section className="flex-1 px-4 pb-12">
+        <div className="mx-auto grid max-w-5xl gap-4 [grid-template-columns:repeat(auto-fit,minmax(160px,1fr))]">
+          {categories.map((cat) => (
+            <Link
+              key={cat.slug}
+              to={`/${cat.slug}`}
+              className="flex flex-col items-center rounded-lg border bg-white p-4 text-center shadow-sm transition hover:shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              <span className="text-3xl" aria-hidden="true">
+                {cat.emoji}
+              </span>
+              <span className="mt-2 font-medium">{cat.title}</span>
+              {cat.description && (
+                <span className="mt-1 text-sm text-gray-600">
+                  {cat.description}
+                </span>
+              )}
+            </Link>
+          ))}
+        </div>
+      </section>
     </main>
   );
 }
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,15 @@ export interface FavoriteFolder {
   sortMode?: SortMode;
 }
 
+// 메인 페이지 분야 선택용 카테고리 타입
+export interface FieldCategory {
+  slug: string;
+  title: string;
+  emoji: string;
+  description?: string;
+  order?: number;
+}
+
 // 즐겨찾기 구조 확장
 export interface FavoritesData {
   items: string[];


### PR DESCRIPTION
## Summary
- redesign root landing page with hero section and responsive category grid
- add category data source and FieldCategory type
- remove unsupported binary asset to allow PR creation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c11a838978832e851f709aa45ff339