### PR TITLE
feat: expand category grid to six columns

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -492,7 +492,7 @@ export default function App() {
                 {/* ✅ 메인: 카테고리 그리드 (항상 첫 화면에 보이게) */}
                 <section className="mt-6 w-full overflow-x-hidden">
                   <div className="mx-auto w-full max-w-[1180px] px-4 sm:px-5 lg:px-6">
-                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-5 gap-x-2 gap-y-4 min-w-0">
+                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-2 gap-y-4 min-w-0">
                       {categoryOrder.map((category) => (
                         <CategoryCard
                           key={category}


### PR DESCRIPTION
## Summary
- expand category grid on main page to six columns for improved layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c16a3e1c80832eb77139d69a03fdf6