### PR TITLE
feat: expand category grid to six columns

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -492,7 +492,7 @@ export default function App() {
                 {/* ✅ 메인: 카테고리 그리드 (항상 첫 화면에 보이게) */}
                 <section className="mt-6 w-full overflow-x-hidden">
                   <div className="mx-auto w-full max-w-[1180px] px-4 sm:px-5 lg:px-6">
-                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-5 gap-x-2 gap-y-4 min-w-0">
+                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-x-2 gap-y-4 min-w-0">
                       {categoryOrder.map((category) => (
                         <CategoryCard
                           key={category}

--- a/src/pages/CategoryStartPage.tsx
+++ b/src/pages/CategoryStartPage.tsx
@@ -4,20 +4,10 @@ import { useNavigate } from 'react-router-dom';
 import { StartPage } from '../components/StartPage';
 
 import {
-  websites as websitesArchitecture,
-  categoryOrder as orderArchitecture,
-  categoryConfig as configArchitecture,
+  websites as defaultWebsites,
+  categoryOrder as defaultOrder,
+  categoryConfig as defaultConfig,
 } from '../data/websites';
-import {
-  websites as websitesRealEstate,
-  categoryOrder as orderRealEstate,
-  categoryConfig as configRealEstate,
-} from '../data/websites.realestate';
-import {
-  websites as websitesStocks,
-  categoryOrder as orderStocks,
-  categoryConfig as configStocks,
-} from '../data/websites.stocks';
 
 import type { FavoritesData, Website } from '../types';
 import {
@@ -46,19 +36,9 @@ export default function CategoryStartPage({
   // 카테고리별 로컬 폴백 데이터 맵
   const dataMap = {
     architecture: {
-      websites: websitesArchitecture,
-      categoryOrder: orderArchitecture,
-      categoryConfig: configArchitecture,
-    },
-    realestate: {
-      websites: websitesRealEstate,
-      categoryOrder: orderRealEstate,
-      categoryConfig: configRealEstate,
-    },
-    stocks: {
-      websites: websitesStocks,
-      categoryOrder: orderStocks,
-      categoryConfig: configStocks,
+      websites: defaultWebsites,
+      categoryOrder: defaultOrder,
+      categoryConfig: defaultConfig,
     },
   } as const;
 


### PR DESCRIPTION
## Summary
- expand category grid on main page to six columns for improved layout
- remove stale data imports to fix Vercel build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c16a3e1c80832eb77139d69a03fdf6