### PR TITLE
feat: add red question mark fallback favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <text x="12" y="18" text-anchor="middle" font-size="18" fill="#ff0000" font-family="sans-serif">?</text>
+</svg>

--- a/src/components/Favicon.tsx
+++ b/src/components/Favicon.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 
 const FallbackIcon: React.FC<{ size?: number; className?: string }> = ({ size = 16, className }) => (
-  <svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true" className={className}>
-    <circle cx="12" cy="12" r="10"></circle>
-    <text x="12" y="16" textAnchor="middle" fontSize="10">
-      W
-    </text>
-  </svg>
+  <img src="/favicon.svg" width={size} height={size} className={className} alt="" />
 );
 
 export const Favicon: React.FC<{ domain: string; size?: number; className?: string }> = ({ domain, size = 16, className }) => {


### PR DESCRIPTION
## Summary
- add red question mark `favicon.svg` to serve as site and fallback icon
- use the new `favicon.svg` as fallback when external favicon fails to load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c18d91adac832e8e2b965b29cc844e