### PR TITLE
feat: add fallback favicon and category-specific website lists

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <text x="12" y="18" text-anchor="middle" font-size="18" fill="#ff0000" font-family="sans-serif">?</text>
+</svg>

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -14,7 +14,6 @@ function RoutedCategoryStartPage() {
     <CategoryStartPage
       categorySlug={slug}
       title="나의 시작페이지"
-      jsonFile="websites.json"
       storageNamespace={`favorites:${slug}`}
     />
   );

--- a/src/components/Favicon.tsx
+++ b/src/components/Favicon.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 
 const FallbackIcon: React.FC<{ size?: number; className?: string }> = ({ size = 16, className }) => (
-  <svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true" className={className}>
-    <circle cx="12" cy="12" r="10"></circle>
-    <text x="12" y="16" textAnchor="middle" fontSize="10">
-      W
-    </text>
-  </svg>
+  <img src="/favicon.svg" width={size} height={size} className={className} alt="" />
 );
 
 export const Favicon: React.FC<{ domain: string; size?: number; className?: string }> = ({ domain, size = 16, className }) => {

--- a/src/pages/CategoryStartPage.tsx
+++ b/src/pages/CategoryStartPage.tsx
@@ -8,6 +8,16 @@ import {
   categoryOrder as defaultOrder,
   categoryConfig as defaultConfig,
 } from '../data/websites';
+import {
+  websites as realestateWebsites,
+  categoryOrder as realestateOrder,
+  categoryConfig as realestateConfig,
+} from '../data/websites.realestate';
+import {
+  websites as stocksWebsites,
+  categoryOrder as stocksOrder,
+  categoryConfig as stocksConfig,
+} from '../data/websites.stocks';
 
 import type { FavoritesData, Website } from '../types';
 import {
@@ -29,7 +39,7 @@ type Props = {
 export default function CategoryStartPage({
   categorySlug,
   title = '나의 시작페이지',
-  jsonFile = 'websites.json',
+  jsonFile,
   storageNamespace = `favorites:${categorySlug}`,
 }: Props) {
   const navigate = useNavigate();
@@ -41,6 +51,16 @@ export default function CategoryStartPage({
       categoryOrder: defaultOrder,
       categoryConfig: defaultConfig,
     },
+    realestate: {
+      websites: realestateWebsites,
+      categoryOrder: realestateOrder,
+      categoryConfig: realestateConfig,
+    },
+    stocks: {
+      websites: stocksWebsites,
+      categoryOrder: stocksOrder,
+      categoryConfig: stocksConfig,
+    },
   } as const;
 
   const fallback =
@@ -50,7 +70,7 @@ export default function CategoryStartPage({
     loadFavoritesData(storageNamespace),
   );
   const [websites, setWebsites] = useState<Website[]>(fallback.websites);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!!jsonFile);
 
   const category = categories.find((c) => c.slug === categorySlug);
   const categoryTitle = category?.title || categorySlug;
@@ -73,6 +93,10 @@ export default function CategoryStartPage({
 
   // jsonFile이 있으면 성공 시 폴백을 덮어씀
   useEffect(() => {
+    if (!jsonFile) {
+      setLoading(false);
+      return;
+    }
     let cancelled = false;
     (async () => {
       try {


### PR DESCRIPTION
## Summary
- add red question mark `favicon.svg` to serve as site and fallback icon
- load category-specific website lists so each field shows relevant sites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c18d91adac832e8e2b965b29cc844e