### PR TITLE
feat: add field pages and slug-based category routing

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <text x="12" y="18" text-anchor="middle" font-size="18" fill="#ff0000" font-family="sans-serif">?</text>
+</svg>

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -7,6 +7,7 @@ import PostDetail from "./pages/PostDetail";
 import PostWrite from "./pages/PostWrite";
 import MainLanding from "./pages/MainLanding";
 import CategoryStartPage from "./pages/CategoryStartPage";
+import FieldPage from "./pages/FieldPage";
 
 function RoutedCategoryStartPage() {
   const { slug = "architecture" } = useParams();
@@ -14,7 +15,6 @@ function RoutedCategoryStartPage() {
     <CategoryStartPage
       categorySlug={slug}
       title="나의 시작페이지"
-      jsonFile="websites.json"
       storageNamespace={`favorites:${slug}`}
     />
   );
@@ -26,6 +26,7 @@ export default function Root() {
       <>
         <Routes>
           <Route path="/" element={<MainLanding />} />
+          <Route path="/fields/:slug" element={<FieldPage />} />
           <Route path="/category/:slug" element={<RoutedCategoryStartPage />} />
           <Route
             path="/architecture"

--- a/src/components/Favicon.tsx
+++ b/src/components/Favicon.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 
 const FallbackIcon: React.FC<{ size?: number; className?: string }> = ({ size = 16, className }) => (
-  <svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true" className={className}>
-    <circle cx="12" cy="12" r="10"></circle>
-    <text x="12" y="16" textAnchor="middle" fontSize="10">
-      W
-    </text>
-  </svg>
+  <img src="/favicon.svg" width={size} height={size} className={className} alt="" />
 );
 
 export const Favicon: React.FC<{ domain: string; size?: number; className?: string }> = ({ domain, size = 16, className }) => {

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -266,11 +266,14 @@ export function StartPage({
   // websites(상태)를 기준으로 카테고리 묶기
   const categorizedWebsites = useMemo(() => {
     const acc: Record<string, Website[]> = {};
-    categoryOrder.forEach((category) => {
-      acc[category] = websites.filter((site) => site.category === category);
+    categoryOrder.forEach((slug) => {
+      const name = categoryConfig[slug]?.title ?? slug;
+      acc[slug] = websites.filter(
+        (site) => site.category === name || site.categorySlug === slug,
+      );
     });
     return acc;
-  }, [websites, categoryOrder]);
+  }, [websites, categoryOrder, categoryConfig]);
 
   const isEmpty =
     favoritesData.items.length === 0 &&
@@ -368,17 +371,21 @@ export function StartPage({
                     gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
                   }}
                 >
-                  {categoryOrder.map((category) => (
-                    <CategoryCard
-                      key={category}
-                      category={category}
-                      sites={categorizedWebsites[category] || []}
-                      config={categoryConfig[category]}
-                      showDescriptions={showDescriptions}
-                      favorites={favoritesData.items}
-                      onToggleFavorite={handleToggleFavorite}
-                    />
-                  ))}
+                  {categoryOrder.map((slug) => {
+                    const displayName =
+                      categoryConfig[slug]?.title ?? slug;
+                    return (
+                      <CategoryCard
+                        key={slug}
+                        category={displayName}
+                        sites={categorizedWebsites[slug] || []}
+                        config={categoryConfig[slug]}
+                        showDescriptions={showDescriptions}
+                        favorites={favoritesData.items}
+                        onToggleFavorite={handleToggleFavorite}
+                      />
+                    );
+                  })}
                 </div>
               </div>
             </div>

--- a/src/data/websites.ts
+++ b/src/data/websites.ts
@@ -9,9 +9,10 @@ export interface Website {
 
 export interface CategoryConfigMap {
   [key: string]: {
+    title: string;
+    description?: string;
     icon: string;
     iconClass: string;
-    title: string;
   };
 }
 
@@ -126,27 +127,77 @@ export const websites: Website[] = [
 ];
 
 export const categoryConfig = {
-  "디자인": { title: "디자인", icon: "🎨", iconClass: "icon-blue" },
-  "공모전": { title: "공모전", icon: "🏆", iconClass: "icon-yellow" },
-  "채용정보": { title: "채용정보", icon: "💼", iconClass: "icon-green" },
-  "유튜브": { title: "유튜브", icon: "📺", iconClass: "icon-red" },
-  "커뮤니티": { title: "커뮤니티", icon: "👥", iconClass: "icon-indigo" },
-  "지도": { title: "지도", icon: "📍", iconClass: "icon-teal" },
-  "건축가": { title: "건축가", icon: "👨‍💼", iconClass: "icon-purple" },
-  "포털사이트": { title: "포털사이트", icon: "🌐", iconClass: "icon-orange" },
-  "기타": { title: "기타", icon: "📚", iconClass: "icon-gray" },
-  "자료" : { title: "기타", icon: "📚", iconClass: "icon-gray" },
+  design: {
+    title: "디자인",
+    description: "디자인 영감/뉴스/자료",
+    icon: "🎨",
+    iconClass: "icon-blue",
+  },
+  contest: {
+    title: "공모전",
+    description: "공모전·경연 정보",
+    icon: "🏆",
+    iconClass: "icon-yellow",
+  },
+  jobs: {
+    title: "채용정보",
+    description: "채용 공고 및 취업 정보",
+    icon: "💼",
+    iconClass: "icon-green",
+  },
+  youtube: {
+    title: "유튜브",
+    description: "관련 유튜브 채널",
+    icon: "📺",
+    iconClass: "icon-red",
+  },
+  community: {
+    title: "커뮤니티",
+    description: "온라인 커뮤니티",
+    icon: "👥",
+    iconClass: "icon-indigo",
+  },
+  map: {
+    title: "지도",
+    description: "지도/로드뷰/길찾기",
+    icon: "📍",
+    iconClass: "icon-teal",
+  },
+  architect: {
+    title: "건축가",
+    description: "건축가 아카이브",
+    icon: "👨‍💼",
+    iconClass: "icon-purple",
+  },
+  portal: {
+    title: "포털사이트",
+    description: "검색 포털",
+    icon: "🌐",
+    iconClass: "icon-orange",
+  },
+  etc: {
+    title: "기타",
+    description: "기타 유용한 사이트",
+    icon: "📚",
+    iconClass: "icon-gray",
+  },
+  reference: {
+    title: "자료",
+    description: "자료/법규/데이터",
+    icon: "📚",
+    iconClass: "icon-gray",
+  },
 };
 
 export const categoryOrder = [
-    "디자인",
-  "공모전",
-  "채용정보",
-  "유튜브",
-  "커뮤니티",
-  "지도",
-  "건축가",
-  "포털사이트",
-  "기타",
-  "자료",
+  "design",
+  "contest",
+  "jobs",
+  "youtube",
+  "community",
+  "map",
+  "architect",
+  "portal",
+  "etc",
+  "reference",
 ];

--- a/src/pages/CategoryStartPage.tsx
+++ b/src/pages/CategoryStartPage.tsx
@@ -8,6 +8,16 @@ import {
   categoryOrder as defaultOrder,
   categoryConfig as defaultConfig,
 } from '../data/websites';
+import {
+  websites as realestateWebsites,
+  categoryOrder as realestateOrder,
+  categoryConfig as realestateConfig,
+} from '../data/websites.realestate';
+import {
+  websites as stocksWebsites,
+  categoryOrder as stocksOrder,
+  categoryConfig as stocksConfig,
+} from '../data/websites.stocks';
 
 import type { FavoritesData, Website } from '../types';
 import {
@@ -29,7 +39,7 @@ type Props = {
 export default function CategoryStartPage({
   categorySlug,
   title = '나의 시작페이지',
-  jsonFile = 'websites.json',
+  jsonFile,
   storageNamespace = `favorites:${categorySlug}`,
 }: Props) {
   const navigate = useNavigate();
@@ -41,6 +51,16 @@ export default function CategoryStartPage({
       categoryOrder: defaultOrder,
       categoryConfig: defaultConfig,
     },
+    realestate: {
+      websites: realestateWebsites,
+      categoryOrder: realestateOrder,
+      categoryConfig: realestateConfig,
+    },
+    stocks: {
+      websites: stocksWebsites,
+      categoryOrder: stocksOrder,
+      categoryConfig: stocksConfig,
+    },
   } as const;
 
   const fallback =
@@ -50,7 +70,7 @@ export default function CategoryStartPage({
     loadFavoritesData(storageNamespace),
   );
   const [websites, setWebsites] = useState<Website[]>(fallback.websites);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!!jsonFile);
 
   const category = categories.find((c) => c.slug === categorySlug);
   const categoryTitle = category?.title || categorySlug;
@@ -73,6 +93,10 @@ export default function CategoryStartPage({
 
   // jsonFile이 있으면 성공 시 폴백을 덮어씀
   useEffect(() => {
+    if (!jsonFile) {
+      setLoading(false);
+      return;
+    }
     let cancelled = false;
     (async () => {
       try {

--- a/src/pages/FieldPage.tsx
+++ b/src/pages/FieldPage.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import type { Website } from "../types";
+import { categoryConfig, websites as websitesLocal } from "../data/websites";
+
+export default function FieldPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const [websites, setWebsites] = useState<Website[] | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await fetch("/websites.json", { cache: "no-store" });
+        if (!res.ok) throw new Error("failed");
+        const data: Website[] = await res.json();
+        if (mounted) setWebsites(data);
+      } catch {
+        setError(true);
+        if (mounted) setWebsites(websitesLocal);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const categoryInfo = slug ? categoryConfig[slug] : undefined;
+
+  const filtered = useMemo(() => {
+    if (!websites || !slug) return [];
+    const name = categoryInfo?.title ?? slug;
+    return websites.filter(
+      (w) => w.category === name || w.categorySlug === slug,
+    );
+  }, [websites, slug, categoryInfo]);
+
+  if (!slug || !categoryInfo) {
+    return (
+      <div className="p-6">
+        <p className="mb-4">알 수 없는 분야입니다.</p>
+        <Link to="/" className="text-blue-600 underline">
+          홈으로 돌아가기
+        </Link>
+      </div>
+    );
+  }
+
+  if (!websites) return <div className="p-6">로딩 중…</div>;
+
+  if (filtered.length === 0) {
+    return (
+      <div className="p-6">
+        <h1 className="text-2xl font-bold mb-4">{categoryInfo.title}</h1>
+        {error && (
+          <p className="mb-2 text-sm text-gray-500">
+            사이트 목록을 불러오지 못해 로컬 데이터로 표시합니다.
+          </p>
+        )}
+        <p>표시할 사이트가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">{categoryInfo.title}</h1>
+      {error && (
+        <p className="mb-4 text-sm text-gray-500">
+          사이트 목록을 불러오지 못해 로컬 데이터로 표시합니다.
+        </p>
+      )}
+      <ul className="space-y-3">
+        {filtered.map((site) => (
+          <li key={site.id} className="border-b pb-2">
+            <a
+              href={site.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              {site.title}
+            </a>
+            {site.description && (
+              <p className="text-sm text-gray-600">{site.description}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/pages/MainLanding.tsx
+++ b/src/pages/MainLanding.tsx
@@ -76,7 +76,7 @@ export default function MainLanding() {
             return (
               <Link
                 key={cat.slug}
-                to={cat.href ?? `/category/${cat.slug}`}
+                to={cat.href ?? `/fields/${cat.slug}`}
                 className={className}
               >
                 {content}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,11 +10,15 @@ export interface Website {
   clicks?: number;
   favorites?: number;
   addedAt?: number;
+  /** optional slug-based category identifier */
+  categorySlug?: string;
 }
 
 export interface CategoryConfig {
+  title: string;
+  description?: string;
   icon: string;
-  iconClass: string;
+  iconClass?: string;
 }
 
 export type CategoryConfigMap = Record<string, CategoryConfig>;


### PR DESCRIPTION
## Summary
- add `/fields/:slug` route and FieldPage to display recommended sites with remote fetch and local fallback
- switch category data to slug-based config and update StartPage grouping
- route home category cards to field pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c18d91adac832e8e2b965b29cc844e