### PR TITLE
feat: add insurance persona pages

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -9,6 +9,8 @@ import MainLanding from "./pages/MainLanding";
 import CategoryStartPage from "./pages/CategoryStartPage";
 import FieldPage from "./pages/FieldPage";
 import RealEstateRoleSelect from "./pages/RealEstateRoleSelect";
+import { PersonaPicker } from "@/modules/insurance/PersonaPicker";
+import InsurancePersonaPage from "@/modules/insurance/PersonaPage";
 
 function RoutedCategoryStartPage() {
   const { slug = "architecture" } = useParams();
@@ -52,6 +54,11 @@ export default function Root() {
           <Route
             path="/category/realestate/:role"
             element={<RoutedRealEstateRoleStartPage />}
+          />
+          <Route path="/category/insurance" element={<PersonaPicker />} />
+          <Route
+            path="/category/insurance/:persona"
+            element={<InsurancePersonaPage />}
           />
           <Route path="/category/:slug" element={<RoutedCategoryStartPage />} />
           <Route

--- a/src/modules/insurance/PersonaPage.tsx
+++ b/src/modules/insurance/PersonaPage.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { siteCatalog } from "./sites";
+import { personaBundles } from "./persona-bundles";
+import { sortSites } from "./sortSites";
+// TODO: 실제 URL 채우기, 퍼소나 세분화, 배지 색상 매핑 등 개선 필요
+
+// ★ 기존 카드 컴포넌트/스타일을 그대로 재사용하세요.
+//    props는 title/url/description/id/sourceType만 맞춰 주면 됩니다.
+import { CategoryCard } from "@/components/CategoryCard"; // 이미 있는 카드(별/메모 버튼 포함 가정)
+
+export default function InsurancePersonaPage() {
+  const { persona } = useParams();
+  const bundle = useMemo(() => personaBundles.find(b => b.persona === persona), [persona]);
+  const id2site = useMemo(() => Object.fromEntries(siteCatalog.map(s => [s.id, s])), []);
+
+  if (!bundle) return <div className="p-6">잘못된 경로입니다.</div>;
+  const sites = bundle.siteIds.map(id => id2site[id]).filter(Boolean).sort(sortSites);
+
+  return (
+    <div className="mx-auto max-w-6xl px-4">
+      <h1 className="text-xl font-bold my-4">보험 · {String(persona)}</h1>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {sites.map(s => (
+          <CategoryCard
+            key={s.id}
+            id={s.id}
+            title={s.title}
+            url={s.url || undefined}
+            description={s.description}
+            badge={s.sourceType}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/insurance/PersonaPicker.tsx
+++ b/src/modules/insurance/PersonaPicker.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router-dom";
+
+const items = [
+  { key:"consumer", label:"개인고객", emoji:"🙋" },
+  { key:"agent", label:"설계사", emoji:"💼" },
+  { key:"expert", label:"전문가", emoji:"🧠" },
+  { key:"corporate", label:"기업·단체", emoji:"🏢" },
+  { key:"licensePrep", label:"취업·수험", emoji:"📚" },
+  { key:"overseas", label:"해외/유학생", emoji:"🌏" },
+];
+
+export function PersonaPicker() {
+  return (
+    <div className="mx-auto max-w-6xl px-4">
+      <h1 className="text-center text-2xl font-bold my-6">보험 사용자 선택</h1>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {items.map(it=>(
+          <Link key={it.key} to={`/category/insurance/${it.key}`}
+            className="rounded-xl border p-5 hover:shadow">
+            <div className="text-3xl">{it.emoji}</div>
+            <div className="mt-2 font-semibold">{it.label}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/insurance/persona-bundles.ts
+++ b/src/modules/insurance/persona-bundles.ts
@@ -1,0 +1,28 @@
+import type { PersonaBundle } from "./taxonomy";
+
+export const personaBundles: PersonaBundle[] = [
+  { persona:"consumer", defaultTags:["비교","청구","공시"], siteIds:[
+    "ins-compare","ins-klia","ins-knia","ins-direct","ins-nhis",
+    "ins-hira","ins-fss","ins-gov24","ins-taas","ins-privacy"
+  ]},
+  { persona:"agent", defaultTags:["리드","설계","준법"], siteIds:[
+    "ins-ad","ins-klia","ins-knia","ins-kidi","ins-lead",
+    "ins-crm","ins-compare","ins-direct","ins-fss","ins-gov24"
+  ]},
+  { persona:"expert", defaultTags:["언더라이팅","판례","통계"], siteIds:[
+    "ins-uw","ins-claimlaw","ins-kidi","ins-klia","ins-knia",
+    "ins-ifrs","ins-fsc","ins-fss","ins-gov24","ins-taas"
+  ]},
+  { persona:"corporate", defaultTags:["B2B","위험관리"], siteIds:[
+    "ins-kidi","ins-knia","ins-klia","ins-fsc","ins-fss",
+    "ins-compare","ins-direct","ins-gov24","ins-privacy","ins-ifrs"
+  ]},
+  { persona:"licensePrep", defaultTags:["교육","시험"], siteIds:[
+    "ins-exam","ins-edu","ins-klia","ins-knia","ins-kidi",
+    "ins-fss","ins-fsc","ins-gov24","ins-ifrs","ins-privacy"
+  ]},
+  { persona:"overseas", defaultTags:["해외","여행","청구"], siteIds:[
+    "ins-over","ins-travelclaim","ins-compare","ins-direct","ins-fss",
+    "ins-gov24","ins-nhis","ins-hira","ins-privacy","ins-klia"
+  ]},
+];

--- a/src/modules/insurance/sites.ts
+++ b/src/modules/insurance/sites.ts
@@ -1,0 +1,36 @@
+import type { Site } from "./taxonomy";
+
+export const siteCatalog: Site[] = [
+  // 공공/협회
+  { id:"ins-fss",  title:"금융감독원 소비자포털", url:"", description:"민원·분쟁조정·소비자보호", sourceType:"public", tags:["민원","분쟁","규제"] },
+  { id:"ins-fsc",  title:"금융위원회", url:"", description:"감독규정·정책·제도 변경", sourceType:"public", tags:["규제","정책"] },
+  { id:"ins-klia", title:"생명보험협회 공시실", url:"", description:"생보 상품 공시/비교/약관", sourceType:"association", tags:["공시","약관"] },
+  { id:"ins-knia", title:"손해보험협회 공시실", url:"", description:"손보 상품 공시/비교/약관", sourceType:"association", tags:["공시","약관"] },
+  { id:"ins-kidi", title:"보험개발원 통계/요율", url:"", description:"요율/손해율/리스크", sourceType:"stats", tags:["통계","요율"] },
+  { id:"ins-nhis", title:"국민건강보험공단", url:"", description:"자격득실/보험료/청구", sourceType:"public", tags:["의료","실손","청구"] },
+  { id:"ins-hira", title:"건강보험심사평가원", url:"", description:"진료내역·제증명·처방", sourceType:"public", tags:["의료","증빙","청구"] },
+  { id:"ins-gov24",title:"정부24", url:"", description:"각종 민원/증명/전자문서", sourceType:"public", tags:["민원","증빙"] },
+  { id:"ins-taas", title:"도로교통공단 TAAS", url:"", description:"교통사고 통계/분석", sourceType:"public", tags:["자동차","보상","통계"] },
+  { id:"ins-privacy", title:"개인정보보호포털", url:"", description:"개인정보 분쟁/가이드", sourceType:"public", tags:["준법","민원"] },
+
+  // 비교/가입/다이렉트(묶음)
+  { id:"ins-compare", title:"공식 보험 비교(보험 비교 포털)", url:"", description:"공식 비교/가격/보장", sourceType:"compare", tags:["비교","가입"] },
+  { id:"ins-direct",  title:"보험사 다이렉트 모음", url:"", description:"자동차/운전자/여행 등", sourceType:"insurer", tags:["가입","자동차","여행"] },
+
+  // 설계사/전문가
+  { id:"ins-ad",    title:"광고심의/준법 가이드", url:"", description:"광고 심의 기준/절차/예시", sourceType:"association", tags:["광고심의","준법"] },
+  { id:"ins-uw",    title:"언더라이팅 가이드",   url:"", description:"인수지침/리스크/사례", sourceType:"tool", tags:["언더라이팅"] },
+  { id:"ins-claimlaw", title:"보험 판례/유권해석", url:"", description:"분쟁/판례/해석", sourceType:"public", tags:["판례","보상"] },
+  { id:"ins-ifrs",  title:"IFRS/계리 자료",  url:"", description:"IFRS17/리스크/계리", sourceType:"stats", tags:["IFRS","계리"] },
+  { id:"ins-lead",  title:"리드 생성 채널/템플릿", url:"", description:"콘텐츠/검색/로컬 전략", sourceType:"tool", tags:["영업","리드"] },
+  { id:"ins-crm",   title:"고객관리/CRM 툴",   url:"", description:"상담·보장분석·후속관리", sourceType:"tool", tags:["CRM","설계"] },
+
+  // 교육/시험
+  { id:"ins-edu",   title:"보험 교육/연수원", url:"", description:"자격/보수교육/강의", sourceType:"edu", tags:["교육","자격"] },
+  { id:"ins-exam",  title:"자격시험 안내(설계사/손사/계리)", url:"", description:"일정/과목/교재", sourceType:"public", tags:["시험","자격"] },
+
+  // 해외
+  { id:"ins-over",  title:"해외유학/체류 정보(정부)", url:"", description:"비자/체류/보건 안내", sourceType:"public", tags:["해외","유학생"] },
+  { id:"ins-travelclaim", title:"해외여행보험 청구 가이드", url:"", description:"서류/절차/연락처", sourceType:"tool", tags:["여행","청구"] },
+];
+

--- a/src/modules/insurance/sortSites.ts
+++ b/src/modules/insurance/sortSites.ts
@@ -1,0 +1,3 @@
+import type { Site } from "./taxonomy";
+const order = { public:1, association:2, insurer:3, compare:4, edu:5, stats:6, tool:7, community:8 } as const;
+export const sortSites = (a:Site,b:Site) => (order[a.sourceType]??99)-(order[b.sourceType]??99);

--- a/src/modules/insurance/taxonomy.ts
+++ b/src/modules/insurance/taxonomy.ts
@@ -1,0 +1,27 @@
+export type SourceType =
+  | "public" | "association" | "insurer" | "compare" | "edu" | "stats" | "tool" | "community";
+
+export type Persona =
+  | "consumer"     // 개인고객
+  | "agent"        // 설계사/GA/조직장
+  | "expert"       // 언더라이터/보상/계리
+  | "corporate"    // 기업·단체 고객
+  | "licensePrep"  // 취업·수험(설계사/손사/계리)
+  | "overseas";    // 해외거주·유학생
+
+export interface Site {
+  id: string;              // 전역 충돌 방지: 모두 "ins-" 프리픽스
+  title: string;
+  url: string;             // (우선 빈 문자열 허용)
+  description: string;
+  sourceType: SourceType;
+  tags?: string[];         // intent/product 키워드 힌트
+}
+
+export interface PersonaBundle {
+  persona: Persona;
+  // 초기 필터 프리셋(사용 안 할 수도 있음)
+  defaultTags?: string[];
+  // 카드에 보여줄 사이트 10개(고정)
+  siteIds: string[];
+}


### PR DESCRIPTION
## Summary
- define insurance taxonomy types and site catalog
- add persona bundles and sorting helper
- implement insurance persona picker and page and wire routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c50851397c832e82d5fcdbbabe42e9