### PR TITLE
feat: allow dragging favorites into folders

### DIFF
--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -143,11 +143,16 @@ function SimpleFolder({
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
+    e.stopPropagation();
+    // 폴더 강조 표시 제거
+    onDragLeaveFolder(e);
     try {
       const websiteId =
         e.dataTransfer.getData('websiteId') ||
         e.dataTransfer.getData('text/plain');
-      if (websiteId) onDropWebsite(websiteId, folder.id);
+      if (websiteId) {
+        onDropWebsite(websiteId, folder.id);
+      }
     } catch (err) {
       console.error('드롭 처리 실패:', err);
     }
@@ -164,18 +169,22 @@ function SimpleFolder({
 
   return (
     <div
-      className={`folder-card border-2 border-dashed p-3 rounded-lg flex flex-col transition-all cursor-move ${
+      className={`folder-card border-2 border-dashed p-3 rounded-lg flex flex-col items-start transition-all cursor-move ${
         isDraggingOver
           ? 'urwebs-drop-zone'
           : 'bg-gray-50 dark:bg-gray-800 dark:border-gray-600'
       }`}
       draggable
       onDragStart={handleFolderDragStart}
-      onDragOver={onDragOverFolder}
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        onDragOverFolder(e);
+      }}
       onDragLeave={onDragLeaveFolder}
       onDrop={handleDrop}
     >
-      <div className="controls flex items-center gap-2 mb-2">
+      <div className="controls w-full flex items-center gap-2 mb-2">
         <span className="text-sm">📁</span>
 
         {isEditing ? (
@@ -230,7 +239,7 @@ function SimpleFolder({
         </button>
       </div>
 
-      <div className="flex-1 flex flex-col gap-1">{children}</div>
+      <div className="w-full flex flex-col gap-1">{children}</div>
     </div>
   );
 }
@@ -513,15 +522,17 @@ export function FavoritesSectionNew({
   };
 
   const moveWebsiteToFolder = (websiteId: string, toFolderId: string) => {
-    const newData = { ...favoritesData };
-    newData.items = (newData.items || []).filter((id) => id !== websiteId);
-    newData.folders = (newData.folders || []).map((folder) => ({
-      ...folder,
-      items: folder.items.filter((id) => id !== websiteId),
-    }));
-    const folderIndex = newData.folders.findIndex((f) => f.id === toFolderId);
-    if (folderIndex >= 0) newData.folders[folderIndex].items.push(websiteId);
-    onUpdateFavorites(newData);
+    const updated: FavoritesData = {
+      ...favoritesData,
+      items: (favoritesData.items || []).filter((id) => id !== websiteId),
+      folders: (favoritesData.folders || []).map((f) =>
+        f.id === toFolderId
+          ? { ...f, items: [...new Set([...(f.items || []), websiteId])] }
+          : { ...f, items: (f.items || []).filter((id) => id !== websiteId) }
+      ),
+    };
+
+    onUpdateFavorites(updated);
   };
 
   const createFolder = () => {


### PR DESCRIPTION
## Summary
- allow folder drop zones to accept dragged bookmarks
- clear hover highlight after dropping to a folder
- keep dropped bookmarks visible inside folders and show folder titles at the top-left

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c566a12624832eb14ffc4b187b40ab