### PR TITLE
feat: add folder creation button

### DIFF
--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -10,6 +10,7 @@ import { TodoWidget } from './widgets/TodoWidget';
 import { CategoryCard } from './CategoryCard';
 import { SiteIcon } from './SiteIcon';
 import { validateCategoryKeys } from '../utils/validateCategories';
+import { AddFolderButton } from './AddFolderButton';
 
 interface StartPageProps {
   favoritesData: FavoritesData;
@@ -127,6 +128,18 @@ export function StartPage({
       layout: [...(favoritesData.layout || []), `widget:${id}`],
     });
     setShowWidgetPicker(false);
+  };
+
+  const handleAddFolder = () => {
+    const name = prompt('폴더 이름을 입력하세요');
+    if (!name) return;
+    const id = `folder-${Date.now()}`;
+    const newFolder = { id, name, items: [] } as any;
+    onUpdateFavorites({
+      ...favoritesData,
+      folders: [...favoritesData.folders, newFolder],
+      layout: [...(favoritesData.layout || []), `folder:${id}`],
+    });
   };
 
   const handleToggleFavorite = (websiteId: string) => {
@@ -392,6 +405,7 @@ export function StartPage({
               >
                 위젯 추가
               </button>
+              <AddFolderButton onClick={handleAddFolder} />
               <button
                 onClick={onClose}
                 aria-label="닫기"


### PR DESCRIPTION
## Summary
- allow creating folders on start page
- wire up new AddFolderButton to prompt for folder name and update favorites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5744e21a4832eb54f8496e3b01a9e