### PR TITLE
fix: correct lucide icon import to resolve Vercel build error

### DIFF
--- a/src/components/AddFolderButton.tsx
+++ b/src/components/AddFolderButton.tsx
@@ -1,4 +1,4 @@
-import { IconFolderPlus } from "lucide-react";
+import { FolderPlus } from "lucide-react";
 
 interface AddFolderButtonProps {
   onClick: () => void;
@@ -12,7 +12,7 @@ export function AddFolderButton({ onClick }: AddFolderButtonProps) {
       className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
       type="button"
     >
-      <IconFolderPlus className="w-4 h-4" />
+      <FolderPlus className="w-4 h-4" />
       폴더 추가
     </button>
   );


### PR DESCRIPTION
## Summary
- import the proper FolderPlus icon from lucide-react
- replace icon usage to fix build failure on Vercel

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c57b37ffcc832e9c72a67075d73152