### PR TITLE
fix: show folder add button by using correct icon

### DIFF
--- a/src/components/AddFolderButton.tsx
+++ b/src/components/AddFolderButton.tsx
@@ -1,4 +1,4 @@
-import { IconFolderPlus } from "lucide-react";
+import { FolderPlus } from "lucide-react";
 
 interface AddFolderButtonProps {
   onClick: () => void;
@@ -12,7 +12,7 @@ export function AddFolderButton({ onClick }: AddFolderButtonProps) {
       className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
       type="button"
     >
-      <IconFolderPlus className="w-4 h-4" />
+      <FolderPlus className="w-4 h-4" />
       폴더 추가
     </button>
   );


### PR DESCRIPTION
## Summary
- import FolderPlus icon correctly for AddFolderButton so folder creation button appears

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57dc30e2c832e8050a4745d4af37f