### PR TITLE
feat: add board buttons to start page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -592,6 +592,7 @@ export default function App() {
                 onUpdateFavorites={setFavoritesData}
                 onClose={() => setCurrentView("home")}
                 showDescriptions={showDescriptions}
+                onContactClick={() => setIsContactModalOpen(true)}
               />
             )}
 

--- a/src/components/AddFolderButton.tsx
+++ b/src/components/AddFolderButton.tsx
@@ -1,4 +1,4 @@
-import { IconFolderPlus } from "lucide-react";
+import { FolderPlus } from "lucide-react";
 
 interface AddFolderButtonProps {
   onClick: () => void;
@@ -12,7 +12,7 @@ export function AddFolderButton({ onClick }: AddFolderButtonProps) {
       className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-1"
       type="button"
     >
-      <IconFolderPlus className="w-4 h-4" />
+      <FolderPlus className="w-4 h-4" />
       폴더 추가
     </button>
   );

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
+import { useNavigate } from 'react-router-dom';
 import { Widget, FavoritesData, Website, CategoryConfigMap } from '../types';
 import { WeatherWidget } from './widgets/WeatherWidget';
 import { ClockWidget } from './widgets/ClockWidget';
@@ -27,6 +28,7 @@ interface StartPageProps {
   onReset?: () => Promise<void> | void;
   showStartGuide?: boolean;
   showDesktop?: boolean;
+  onContactClick?: () => void;
 }
 
 export function StartPage({
@@ -44,12 +46,17 @@ export function StartPage({
   onReset,
   showStartGuide = true,
   showDesktop = true,
+  onContactClick,
 }: StartPageProps) {
   const [currentTime, setCurrentTime] = useState(new Date());
   useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
     return () => clearInterval(timer);
   }, []);
+
+  const navigate = useNavigate();
+  const handleNoticeClick = () => navigate('/notice');
+  const handleBoardClick = () => navigate('/free');
 
   // ===== UI states =====
   const [showWidgetPicker, setShowWidgetPicker] = useState(false);
@@ -377,6 +384,28 @@ export function StartPage({
 
       <div className="min-h-screen mx-auto px-4 md:px-6" style={{ maxWidth: '1440px' }}>
         <div className="py-8 space-y-12">
+          {/* Top links */}
+          <div className="flex justify-end gap-2">
+            <button
+              className="urwebs-btn-ghost flex items-center gap-2 text-sm"
+              onClick={handleNoticeClick}
+            >
+              📢 공지사항
+            </button>
+            <button
+              className="urwebs-btn-ghost flex items-center gap-2 text-sm"
+              onClick={handleBoardClick}
+            >
+              💬 자유게시판
+            </button>
+            <button
+              className="urwebs-btn-ghost flex items-center gap-2 text-sm"
+              onClick={() => onContactClick && onContactClick()}
+            >
+              📞 문의하기
+            </button>
+          </div>
+
           {/* Header */}
           <div className="flex justify-between items-center relative">
             <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- import FolderPlus icon correctly for AddFolderButton so folder creation button appears
- add notice/free board/contact buttons to StartPage and hook contact modal

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57dc30e2c832e8050a4745d4af37f