### PR TITLE
Ensure new favorites appear first

### DIFF
--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -130,10 +130,10 @@ export function StartPage({
     const isFavorited = favoritesData.items.includes(websiteId);
     const updatedItems = isFavorited
       ? favoritesData.items.filter((id) => id !== websiteId)
-      : [...favoritesData.items, websiteId];
+      : [websiteId, ...favoritesData.items];
     const updatedLayout = isFavorited
       ? (favoritesData.layout || []).filter((e) => e !== `item:${websiteId}`)
-      : [...(favoritesData.layout || []), `item:${websiteId}`];
+      : [`item:${websiteId}`, ...(favoritesData.layout || [])];
     onUpdateFavorites({ ...favoritesData, items: updatedItems, layout: updatedLayout });
   };
 

--- a/src/utils/favorites.ts
+++ b/src/utils/favorites.ts
@@ -21,8 +21,9 @@ export function toggleFavorite(
     );
   } else {
     const newItem: FavoriteItem = { id: websiteId, parentId: null };
-    newData.items = [...newData.items, newItem];
-    newData.layout = [...(newData.layout || []), `item:${websiteId}`];
+    // Insert the new favorite at the beginning of items and layout
+    newData.items = [newItem, ...newData.items];
+    newData.layout = [`item:${websiteId}`, ...(newData.layout || [])];
   }
 
   return newData;

--- a/tests/favorites.test.ts
+++ b/tests/favorites.test.ts
@@ -4,9 +4,17 @@ import type { FavoritesData } from '../src/types';
 
 describe('favorites management', () => {
   it('adds a favorite when not present', () => {
-    const data: FavoritesData = { items: [], folders: [], widgets: [], layout: [] };
+    const data: FavoritesData = {
+      items: [{ id: 'site2', parentId: null }],
+      folders: [],
+      widgets: [],
+      layout: ['item:site2'],
+    };
     const updated = toggleFavorite(data, 'site1');
-    expect(updated.items.some((i) => i.id === 'site1')).toBe(true);
+    expect(updated.items[0].id).toBe('site1');
+    expect(updated.items[1].id).toBe('site2');
+    expect(updated.layout[0]).toBe('item:site1');
+    expect(updated.layout[1]).toBe('item:site2');
   });
 
   it('removes a favorite when present', () => {


### PR DESCRIPTION
## Summary
- Add new favorite items at the beginning of favorites data
- Update StartPage to unshift new favorites into items and layout
- Adjust tests to expect new favorites at the front of arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5881cfc94832eaa1a30f096677961