### PR TITLE
Ensure drag-dropped favorites appear first

### DIFF
--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -460,7 +460,8 @@ export function FavoritesSectionNew({
       const newItem = { id: categoryWebsiteId, parentId: targetId || null };
       const newData = {
         ...favoritesData,
-        items: [...favoritesData.items, newItem],
+        items: [newItem, ...favoritesData.items],
+        layout: [`item:${categoryWebsiteId}`, ...(favoritesData.layout || [])],
       };
       onUpdateFavorites(newData);
       toast.success('즐겨찾기에 추가되었습니다.');


### PR DESCRIPTION
## Summary
- Insert new favorites at the beginning of favorites list when dragging from categories
- Update layout to keep drop-in favorites at the top

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c587afd0ec832e9ecc05b024ab710c