### PR TITLE
chore: rewrite unmatched routes to index.html

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,5 +13,12 @@
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     }
+  ],
+  "rewrites": [
+    { "source": "/api/:match*", "destination": "/api/:match*" },
+    { "source": "/assets/:match*", "destination": "/assets/:match*" },
+    { "source": "/images/:match*", "destination": "/images/:match*" },
+    { "source": "/favicon.ico", "destination": "/favicon.ico" },
+    { "source": "/:match*", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- rewrite all non-api and non-static paths to `index.html` for proper client-side routing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58ece9cdc832e93298cda92328dd9