### PR TITLE
feat: update insurance favorites layout

### DIFF
--- a/src/modules/insurance/PersonaPage.tsx
+++ b/src/modules/insurance/PersonaPage.tsx
@@ -1,14 +1,11 @@
 // src/modules/insurance/PersonaPage.tsx
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { StartPage } from "@/components/StartPage";
+import { useParams } from "react-router-dom";
+import { FavoritesSectionNew } from "@/components/FavoritesSectionNew";
+import { CategoryCard } from "@/components/CategoryCard";
 import type { FavoritesData, Website } from "@/types";
-import {
-  loadFavoritesData,
-  saveFavoritesData,
-  applyStarter,
-  resetFavorites,
-} from "@/utils/startPageStorage";
+import { loadFavoritesData, saveFavoritesData } from "@/utils/startPageStorage";
+import { toggleFavorite as toggleFavoriteData } from "@/utils/favorites";
 import { siteCatalog } from "./sites";
 import { personaBundles } from "./persona-bundles";
 import { sortSites } from "./sortSites";
@@ -24,7 +21,6 @@ const personaLabels: Record<string, string> = {
 
 export default function InsurancePersonaPage() {
   const { persona = "" } = useParams<{ persona: string }>();
-  const navigate = useNavigate();
 
   const bundle = useMemo(
     () => personaBundles.find((b) => b.persona === persona),
@@ -65,28 +61,35 @@ export default function InsurancePersonaPage() {
 
   if (!bundle) return <div className="p-6">잘못된 경로입니다.</div>;
 
-  const onApplyStarter = async () => applyStarter(setFavoritesData, storageNamespace);
-  const onReset = async () => resetFavorites(setFavoritesData, storageNamespace);
+  const toggleFavorite = (id: string) => {
+    setFavoritesData((prev) => toggleFavoriteData(prev, id));
+  };
 
+  const favoriteIds = favoritesData.items.map((i) => i.id);
   const categoryTitle = `보험 · ${personaLabels[persona] || persona}`;
 
   return (
-    <StartPage
-      favoritesData={favoritesData}
-      onUpdateFavorites={setFavoritesData}
-      onClose={() => navigate("/")}
-      showDescriptions={true}
-      pageTitle="나의 시작페이지"
-      categoryTitle={categoryTitle}
-      websites={websites}
-      categoryOrder={["insurance"]}
-      categoryConfig={{ insurance: { title: "보험" } }}
-      loading={false}
-      onApplyStarter={onApplyStarter}
-      onReset={onReset}
-      showStartGuide={false}
-      showDesktop={false}
-    />
+    <div className="p-4">
+      <div className="mx-auto max-w-[1180px]">
+        {favoritesData.items.length > 0 && (
+          <FavoritesSectionNew
+            favoritesData={favoritesData}
+            onUpdateFavorites={setFavoritesData}
+          />
+        )}
+        <h2 className="mt-6 mb-4 text-xl font-bold">{categoryTitle}</h2>
+        <div className="grid grid-cols-6 gap-x-2 gap-y-4 min-w-0">
+          <CategoryCard
+            category="insurance"
+            sites={websites}
+            config={{ title: "보험" }}
+            showDescriptions={true}
+            favorites={favoriteIds}
+            onToggleFavorite={toggleFavorite}
+          />
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/utils/startPageStorage.ts
+++ b/src/utils/startPageStorage.ts
@@ -1,4 +1,4 @@
-import { FavoritesData, Widget, SortMode } from '../types';
+import { FavoritesData, Widget, SortMode, FavoriteItem } from '../types';
 import starter from '../data/starter.json';
 
 const DEFAULT_STORAGE_KEY = 'favorites:default';
@@ -22,7 +22,34 @@ const starterData = starter as StarterRaw;
 export function loadFavoritesData(ns = DEFAULT_STORAGE_KEY): FavoritesData {
   try {
     const raw = localStorage.getItem(ns);
-    return raw ? JSON.parse(raw) : { items: [], folders: [], widgets: [], layout: [] };
+    if (!raw) return { items: [], folders: [], widgets: [], layout: [] };
+    const parsed = JSON.parse(raw);
+
+    const items: FavoriteItem[] = [];
+    const folders = Array.isArray(parsed.folders)
+      ? parsed.folders.map((f: any) => {
+          const { id, name, color, sortMode } = f;
+          if (Array.isArray(f.items)) {
+            f.items.forEach((wid: string) =>
+              items.push({ id: wid, parentId: id })
+            );
+          }
+          return { id, name, color, sortMode };
+        })
+      : [];
+
+    if (Array.isArray(parsed.items)) {
+      parsed.items.forEach((it: any) => {
+        if (typeof it === 'string') items.push({ id: it, parentId: null });
+        else if (it && typeof it.id === 'string')
+          items.push({ id: it.id, parentId: it.parentId ?? null });
+      });
+    }
+
+    const widgets: Widget[] = Array.isArray(parsed.widgets) ? parsed.widgets : [];
+    const layout: string[] = Array.isArray(parsed.layout) ? parsed.layout : [];
+
+    return { items, folders, widgets, layout };
   } catch (e) {
     console.error('Failed to load favorites data', e);
     return { items: [], folders: [], widgets: [], layout: [] };
@@ -42,19 +69,30 @@ export function getStarterData(): FavoritesData {
     id: w.id,
     type: w.type,
   }));
+
   const folders = (starterData.folders || []).map((f) => ({
     id: f.id,
     name: f.name,
-    items: f.items || [],
     color: f.color,
     sortMode: f.sortMode,
   }));
-  const items = starterData.favorites || [];
+
+  const items: FavoriteItem[] = [];
+  (starterData.favorites || []).forEach((id) =>
+    items.push({ id, parentId: null })
+  );
+  (starterData.folders || []).forEach((f) => {
+    (f.items || []).forEach((wid) =>
+      items.push({ id: wid, parentId: f.id })
+    );
+  });
+
   const layout = [
-    ...items.map((id) => `item:${id}`),
+    ...items.filter((i) => !i.parentId).map((i) => `item:${i.id}`),
     ...folders.map((f) => `folder:${f.id}`),
     ...widgets.map((w) => `widget:${w.id}`),
   ];
+
   return { items, folders, widgets, layout };
 }
 


### PR DESCRIPTION
## Summary
- refactor insurance persona page to use `FavoritesSectionNew` and `CategoryCard`
- migrate start page storage to `FavoriteItem` structure and update starter data
- adjust legacy `StartPage` component for folder-based favorites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5918cc174832e9cd88bc70f55b465