### PR TITLE
feat: show insurance personas on hover

### DIFF
--- a/src/components/FavoritesSectionNew.tsx
+++ b/src/components/FavoritesSectionNew.tsx
@@ -13,9 +13,7 @@ import { trackVisit, buildFrequencyMap } from '../utils/visitTrack';
 import { sortByMode } from '../utils/sorters';
 import { toast } from 'sonner';
 import { SiteIcon } from './SiteIcon';
-import { GhostBtn, IconStarPlus, IconFolderPlus } from './ui/ghost-btn';
 import { AddFolderButton } from './AddFolderButton';
-import { saveBookmark } from '../services/bookmarks';
 
 interface FavoritesSectionProps {
   favoritesData: FavoritesData;
@@ -391,22 +389,6 @@ export function FavoritesSectionNew({
   const [draggedId, setDraggedId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
 
-  function onAddFavorite() {
-    const title = document.title;
-    const url = window.location.href;
-    saveBookmark({ title, url, favicon: null, folderId: null })
-      .then((r) => {
-        if (r.mode === 'guest')
-          toast('로그인 없이 임시로 담았어요. 로그인하면 저장됩니다.');
-        else toast('즐겨찾기에 추가했어요!');
-      })
-      .catch(() => toast('저장 실패: 잠시 후 다시 시도해주세요.'));
-  }
-
-  function onAddFolder() {
-    setShowNewFolderInput(true);
-  }
-
   const handleDragStart = (e: React.DragEvent, id: string) => {
     setDraggedId(id);
     try {
@@ -724,14 +706,6 @@ export function FavoritesSectionNew({
           </div>
         )}
 
-        <div className="toolbar btn-group mb-4">
-          <GhostBtn icon={<IconStarPlus />} hint="Ctrl+D" onClick={onAddFavorite}>
-            이 페이지를 즐겨찾기에 추가
-          </GhostBtn>
-          <GhostBtn icon={<IconFolderPlus />} onClick={onAddFolder}>
-            폴더 추가
-          </GhostBtn>
-        </div>
         <div className="grid grid-cols-1 md:grid-cols-6 gap-x-4 gap-y-6">
           {/* 즐겨찾기 리스트 */}
           <div className="space-y-2 lg:space-y-3 md:col-span-1 xl:col-span-1">

--- a/src/modules/insurance/PersonaPicker.tsx
+++ b/src/modules/insurance/PersonaPicker.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 
-const items = [
+export const insurancePersonaItems = [
   { key: "consumer", label: "개인고객", icon: "🙋" },
   { key: "agent", label: "설계사", icon: "💼" },
   { key: "expert", label: "전문가", icon: "🧠" },
@@ -14,7 +14,7 @@ export function PersonaPicker() {
     <div className="mx-auto max-w-6xl px-4">
       <h1 className="text-center text-2xl font-bold my-6">보험 사용자 선택</h1>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {items.map(it=>(
+        {insurancePersonaItems.map((it) => (
           <Link key={it.key} to={`/category/insurance/${it.key}`}
             className="rounded-xl border p-5 hover:shadow">
             <div className="text-3xl">{it.icon}</div>

--- a/src/pages/MainLanding.tsx
+++ b/src/pages/MainLanding.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import categoriesData from "../data/categories";
+import { insurancePersonaItems } from "@/modules/insurance/PersonaPicker";
 
 export default function MainLanding() {
   const categories = [...categoriesData].sort(
@@ -64,6 +65,27 @@ export default function MainLanding() {
             const className =
               "flex flex-col items-center rounded-lg border bg-white p-4 text-center shadow-sm transition hover:shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500";
 
+            // 보험 카테고리는 호버 시 바로 페르소나 선택을 표시
+            if (cat.slug === "insurance") {
+              return (
+                <div key={cat.slug} className="relative group">
+                  <div className={className}>{content}</div>
+                  <div className="absolute inset-0 hidden group-hover:flex flex-col items-center justify-center gap-2 rounded-lg border bg-white p-4 shadow">
+                    {insurancePersonaItems.map((it) => (
+                      <Link
+                        key={it.key}
+                        to={`/category/insurance/${it.key}`}
+                        className="px-2 py-1 hover:underline"
+                      >
+                        <span className="mr-1">{it.icon}</span>
+                        {it.label}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              );
+            }
+
             // href가 http로 시작하면 외부 링크, 아니면 내부 라우팅
             if (cat.href?.startsWith("http")) {
               return (
@@ -83,7 +105,7 @@ export default function MainLanding() {
               <Link
                 key={cat.slug}
                 to={cat.href ?? `/category/${cat.slug}`}
-                className={`${className}${cat.disabled ? ' opacity-50 pointer-events-none' : ''}`}
+                className={`${className}${cat.disabled ? " opacity-50 pointer-events-none" : ""}`}
                 aria-disabled={cat.disabled}
                 onClick={(e) => {
                   if (cat.disabled) {


### PR DESCRIPTION
## Summary
- remove toolbar for adding page to favorites or folders
- display insurance persona options when hovering over the insurance category on the landing page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c59c3a6c88832eb40b95d2cca994d2