### PR TITLE
feat: order marketing and accounting categories

### DIFF
--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -57,6 +57,15 @@ export const categories: FieldCategory[] = [
     icon: '📣',
     description: '콘텐츠 제작과 마케팅',
     href: '/category/marketing',
+    order: 8,
+  },
+  {
+    slug: 'accounting',
+    title: '회계/세무',
+    icon: '📊',
+    description: '회계와 세무 자료',
+    href: '/category/accounting',
+    order: 9,
   },
   {
     slug: 'video',


### PR DESCRIPTION
## Summary
- add sorting `order` for marketing category
- introduce accounting category with its own order for deterministic placement

## Testing
- `npm test`
- `npm run build` *(fails: Duplicate key `embedded` in object literal and unexpected EOF in `websites.embedded.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c63b45e0832e98f7a6ea75e73038