### PR TITLE
feat: order marketing and accounting categories

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  ignorePatterns: ['dist', 'node_modules'],
+  rules: {
+    'no-dupe-keys': 'error',
+    '@typescript-eslint/consistent-type-exports': 'warn',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -53,12 +53,18 @@
             "@types/node": "^20.10.0",
             "@vitejs/plugin-react-swc": "^3.10.2",
             "vite": "6.3.5",
-            "vitest": "^3.2.4"
+            "vitest": "^3.2.4",
+            "typescript": "^5.4.0",
+            "eslint": "^8.57.0",
+            "@typescript-eslint/parser": "^7.7.1",
+            "@typescript-eslint/eslint-plugin": "^7.7.1"
       },
       "scripts": {
             "prebuild": "node scripts/write-status.mjs",
             "dev": "vite",
             "build": "vite build",
-            "test": "vitest run"
+            "test": "vitest run",
+            "lint": "eslint \"src/**/*.{ts,tsx}\"",
+            "typecheck": "tsc --noEmit"
       }
 }

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -57,6 +57,15 @@ export const categories: FieldCategory[] = [
     icon: '📣',
     description: '콘텐츠 제작과 마케팅',
     href: '/category/marketing',
+    order: 8,
+  },
+  {
+    slug: 'accounting',
+    title: '회계/세무',
+    icon: '📊',
+    description: '회계와 세무 자료',
+    href: '/category/accounting',
+    order: 9,
   },
   {
     slug: 'video',

--- a/src/data/websites.embedded.ts
+++ b/src/data/websites.embedded.ts
@@ -87,3 +87,4 @@ export const categoryOrder = [
   '배포·스토어',
   '튜토리얼·학습(한국어/국내용)',
   '커뮤니티/QA',
+];

--- a/src/pages/CategoryStartPage.tsx
+++ b/src/pages/CategoryStartPage.tsx
@@ -116,12 +116,6 @@ export default function CategoryStartPage({
       categoryOrder: insuranceOrder,
       categoryConfig: insuranceConfig,
     },
-
-    embedded: {
-      websites: embeddedWebsites,
-      categoryOrder: embeddedOrder,
-      categoryConfig: embeddedConfig,
-    },
     wedding: {
       websites: weddingWebsites,
       categoryOrder: weddingOrder,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add sorting `order` for marketing category
- introduce accounting category with its own order for deterministic placement
- drop duplicate embedded source and finish embedded websites list
- add eslint config with duplicate-key rule and strict tsconfig options

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@typescript-eslint%2feslint-plugin)*
- `npm test`
- `npm run typecheck` *(fails: Could not find a declaration file for module 'react')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5c63b45e0832e98f7a6ea75e73038