### PR TITLE
fix: import wedding data for category page

### DIFF
--- a/src/pages/CategoryStartPage.tsx
+++ b/src/pages/CategoryStartPage.tsx
@@ -34,6 +34,11 @@ import {
   categoryConfig as insuranceConfig,
 } from '../data/websites.insurance';
 import {
+  websites as weddingWebsites,
+  categoryOrder as weddingOrder,
+  categoryConfig as weddingConfig,
+} from '../data/websites.wedding';
+import {
   websites as videoWebsites,
   categoryOrder as videoOrder,
   categoryConfig as videoConfig,


### PR DESCRIPTION
## Summary
- import missing wedding data in CategoryStartPage to prevent ReferenceError

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c9ef53d0832e9483f0dc784e670c