### PR TITLE
feat: add architecture worker persona

### DIFF
--- a/src/data/personas.ts
+++ b/src/data/personas.ts
@@ -130,8 +130,8 @@ export const personaCategories: PersonaCategory[] = [
     slug: 'architecture',
     title: '건축/BIM/CAD/GIS',
     items: [
-      { slug: 'student', title: '학생' },
-      { slug: 'staff', title: '설계직원' },
+      { slug: 'student', title: '대학생' },
+      { slug: 'worker', title: '직장인' },
     ],
   },
   {

--- a/src/data/websites.architecture.worker.ts
+++ b/src/data/websites.architecture.worker.ts
@@ -1,0 +1,70 @@
+import type { Website, CategoryConfigMap } from './websites';
+
+export const websites: Website[] = [
+  {
+    category: '디자인',
+    title: '아키데일리',
+    url: 'https://www.archdaily.com',
+    description: '세계 최대 건축 아카이브',
+    id: 'AR-WK-DESIGN-001',
+  },
+  {
+    category: '디자인',
+    title: '디즌',
+    url: 'https://www.dezeen.com',
+    description: '건축·디자인 트렌드',
+    id: 'AR-WK-DESIGN-002',
+  },
+  {
+    category: '법규',
+    title: '국가법령정보센터',
+    url: 'https://www.law.go.kr',
+    description: '건축법·시행령·해설',
+    id: 'AR-WK-LAW-001',
+  },
+  {
+    category: '법규',
+    title: '국토법령정보센터',
+    url: 'https://www.luris.go.kr',
+    description: '국토계획·용도지역 안내',
+    id: 'AR-WK-LAW-002',
+  },
+  {
+    category: '행정',
+    title: '세움터',
+    url: 'https://www.eais.go.kr',
+    description: '인허가·대장·행정',
+    id: 'AR-WK-ADM-001',
+  },
+  {
+    category: '행정',
+    title: '정부24',
+    url: 'https://www.gov.kr',
+    description: '민원·행정 서비스',
+    id: 'AR-WK-ADM-002',
+  },
+  {
+    category: '프로그램',
+    title: 'AutoCAD',
+    url: 'https://www.autodesk.com/products/autocad',
+    description: '대표 CAD 소프트웨어',
+    id: 'AR-WK-PROG-001',
+  },
+  {
+    category: '프로그램',
+    title: 'Revit',
+    url: 'https://www.autodesk.com/products/revit',
+    description: 'BIM 설계 도구',
+    id: 'AR-WK-PROG-002',
+  },
+];
+
+export const categoryConfig: CategoryConfigMap = {
+  design: { title: '디자인', icon: '🎨', iconClass: 'icon-blue' },
+  law: { title: '법규', icon: '⚖️', iconClass: 'icon-green' },
+  admin: { title: '행정', icon: '🗂️', iconClass: 'icon-yellow' },
+  program: { title: '프로그램', icon: '💻', iconClass: 'icon-purple' },
+};
+
+export const categoryOrder = ['design', 'law', 'admin', 'program'];
+

--- a/src/pages/CategoryStartPage.tsx
+++ b/src/pages/CategoryStartPage.tsx
@@ -34,6 +34,11 @@ import {
   categoryConfig as insuranceConfig,
 } from '../data/websites.insurance';
 import {
+  websites as weddingWebsites,
+  categoryOrder as weddingOrder,
+  categoryConfig as weddingConfig,
+} from '../data/websites.wedding';
+import {
   websites as videoWebsites,
   categoryOrder as videoOrder,
   categoryConfig as videoConfig,
@@ -43,6 +48,11 @@ import {
   categoryOrder as embeddedOrder,
   categoryConfig as embeddedConfig,
 } from '../data/websites.embedded';
+import {
+  websites as architectureWorkerWebsites,
+  categoryOrder as architectureWorkerOrder,
+  categoryConfig as architectureWorkerConfig,
+} from '../data/websites.architecture.worker';
 import {
 
   websites as marketingWebsites,
@@ -95,6 +105,11 @@ export default function CategoryStartPage({
       websites: defaultWebsites,
       categoryOrder: defaultOrder,
       categoryConfig: defaultConfig,
+    },
+    'architecture-worker': {
+      websites: architectureWorkerWebsites,
+      categoryOrder: architectureWorkerOrder,
+      categoryConfig: architectureWorkerConfig,
     },
     embedded: {
       websites: embeddedWebsites,


### PR DESCRIPTION
## Summary
- add worker persona for architecture
- provide worker-specific website categories for architecture

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c9ef53d0832e9483f0dc784e670c