### PR TITLE
feat: auto persona selection

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -8,38 +8,36 @@ import PostDetail from "./pages/PostDetail";
 import PostWrite from "./pages/PostWrite";
 import MainLanding from "./pages/MainLanding";
 import CategoryStartPage from "./pages/CategoryStartPage";
-import RealEstateRoleSelect from "./pages/RealEstateRoleSelect";
 import PersonaOverview from "./pages/PersonaOverview";
-import { PersonaPicker } from "@/modules/insurance/PersonaPicker";
 import InsurancePersonaPage from "@/modules/insurance/PersonaPage";
+import PersonaSelectPage from "./pages/PersonaSelectPage";
+import { personaCategories } from "@/data/personas";
 
-function RoutedCategoryStartPage() {
-  const { slug = "architecture" } = useParams();
+function RoutedCategoryPage() {
+  const { slug = "architecture" } = useParams<{ slug: string }>();
+
+  const personaCategory = personaCategories.find(
+    (p) => slug === p.slug || slug.startsWith(`${p.slug}-`),
+  );
+
+  if (personaCategory) {
+    const baseSlug = personaCategory.slug;
+    const persona = slug === baseSlug ? undefined : slug.slice(baseSlug.length + 1);
+
+    if (!persona && personaCategory.items.length > 1) {
+      return <PersonaSelectPage slug={baseSlug} />;
+    }
+
+    if (baseSlug === "insurance") {
+      return <InsurancePersonaPage persona={persona ?? ""} />;
+    }
+  }
+
   return (
     <CategoryStartPage
       categorySlug={slug}
       title="나의 시작페이지"
       storageNamespace={`favorites:${slug}`}
-    />
-  );
-}
-
-function RoutedRealEstateRoleStartPage() {
-  const { role = "student" } = useParams();
-  const titleMap = {
-    student: "부동산 - 학생",
-    agent: "부동산 - 공인중개사",
-    tenant: "부동산 - 임차인",
-    landlord: "부동산 - 임대인",
-    investor: "부동산 - 투자자",
-  } as const;
-  const categoryTitle = titleMap[role as keyof typeof titleMap] ?? "부동산";
-  return (
-    <CategoryStartPage
-      categorySlug={`realestate-${role}`}
-      title="나의 시작페이지"
-      storageNamespace={`favorites:realestate-${role}`}
-      categoryTitleOverride={categoryTitle}
     />
   );
 }
@@ -58,17 +56,7 @@ export default function Root() {
           {/* 구 라우트 호환: /fields/:slug -> /category/:slug */}
           <Route path="/fields/:slug" element={<RedirectFieldsToCategory />} />
           <Route path="/personas" element={<PersonaOverview />} />
-          <Route path="/category/realestate" element={<RealEstateRoleSelect />} />
-          <Route
-            path="/category/realestate/:role"
-            element={<RoutedRealEstateRoleStartPage />}
-          />
-          <Route path="/category/insurance" element={<PersonaPicker />} />
-          <Route
-            path="/category/insurance/:persona"
-            element={<InsurancePersonaPage />}
-          />
-          <Route path="/category/:slug" element={<RoutedCategoryStartPage />} />
+          <Route path="/category/:slug" element={<RoutedCategoryPage />} />
           <Route
             path="/architecture"
             element={<Navigate to="/category/architecture" replace />}

--- a/src/data/personas.ts
+++ b/src/data/personas.ts
@@ -130,8 +130,8 @@ export const personaCategories: PersonaCategory[] = [
     slug: 'architecture',
     title: '건축/BIM/CAD/GIS',
     items: [
-      { slug: 'student', title: '학생' },
-      { slug: 'staff', title: '설계직원' },
+      { slug: 'student', title: '대학생' },
+      { slug: 'worker', title: '직장인' },
     ],
   },
   {

--- a/src/data/websites.architecture.worker.ts
+++ b/src/data/websites.architecture.worker.ts
@@ -1,0 +1,70 @@
+import type { Website, CategoryConfigMap } from './websites';
+
+export const websites: Website[] = [
+  {
+    category: '디자인',
+    title: '아키데일리',
+    url: 'https://www.archdaily.com',
+    description: '세계 최대 건축 아카이브',
+    id: 'AR-WK-DESIGN-001',
+  },
+  {
+    category: '디자인',
+    title: '디즌',
+    url: 'https://www.dezeen.com',
+    description: '건축·디자인 트렌드',
+    id: 'AR-WK-DESIGN-002',
+  },
+  {
+    category: '법규',
+    title: '국가법령정보센터',
+    url: 'https://www.law.go.kr',
+    description: '건축법·시행령·해설',
+    id: 'AR-WK-LAW-001',
+  },
+  {
+    category: '법규',
+    title: '국토법령정보센터',
+    url: 'https://www.luris.go.kr',
+    description: '국토계획·용도지역 안내',
+    id: 'AR-WK-LAW-002',
+  },
+  {
+    category: '행정',
+    title: '세움터',
+    url: 'https://www.eais.go.kr',
+    description: '인허가·대장·행정',
+    id: 'AR-WK-ADM-001',
+  },
+  {
+    category: '행정',
+    title: '정부24',
+    url: 'https://www.gov.kr',
+    description: '민원·행정 서비스',
+    id: 'AR-WK-ADM-002',
+  },
+  {
+    category: '프로그램',
+    title: 'AutoCAD',
+    url: 'https://www.autodesk.com/products/autocad',
+    description: '대표 CAD 소프트웨어',
+    id: 'AR-WK-PROG-001',
+  },
+  {
+    category: '프로그램',
+    title: 'Revit',
+    url: 'https://www.autodesk.com/products/revit',
+    description: 'BIM 설계 도구',
+    id: 'AR-WK-PROG-002',
+  },
+];
+
+export const categoryConfig: CategoryConfigMap = {
+  design: { title: '디자인', icon: '🎨', iconClass: 'icon-blue' },
+  law: { title: '법규', icon: '⚖️', iconClass: 'icon-green' },
+  admin: { title: '행정', icon: '🗂️', iconClass: 'icon-yellow' },
+  program: { title: '프로그램', icon: '💻', iconClass: 'icon-purple' },
+};
+
+export const categoryOrder = ['design', 'law', 'admin', 'program'];
+

--- a/src/modules/insurance/PersonaPage.tsx
+++ b/src/modules/insurance/PersonaPage.tsx
@@ -16,8 +16,13 @@ const personaLabels: Record<string, string> = {
   overseas: "해외/유학생",
 };
 
-export default function InsurancePersonaPage() {
-  const { persona = "" } = useParams<{ persona: string }>();
+type Props = {
+  persona?: string;
+};
+
+export default function InsurancePersonaPage({ persona: personaProp }: Props = {}) {
+  const params = useParams<{ persona?: string }>();
+  const persona = personaProp ?? params.persona ?? "";
 
   const bundle = useMemo(
     () => personaBundles.find((b) => b.persona === persona),

--- a/src/modules/insurance/PersonaPicker.tsx
+++ b/src/modules/insurance/PersonaPicker.tsx
@@ -15,7 +15,7 @@ export function PersonaPicker() {
       <h1 className="text-center text-2xl font-bold my-6">보험 사용자 선택</h1>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {insurancePersonaItems.map((it) => (
-          <Link key={it.key} to={`/category/insurance/${it.key}`}
+          <Link key={it.key} to={`/category/insurance-${it.key}`}
             className="rounded-xl border p-5 hover:shadow">
             <div className="text-3xl">{it.icon}</div>
             <div className="mt-2 font-semibold">{it.label}</div>

--- a/src/pages/CategoryStartPage.tsx
+++ b/src/pages/CategoryStartPage.tsx
@@ -34,6 +34,11 @@ import {
   categoryConfig as insuranceConfig,
 } from '../data/websites.insurance';
 import {
+  websites as weddingWebsites,
+  categoryOrder as weddingOrder,
+  categoryConfig as weddingConfig,
+} from '../data/websites.wedding';
+import {
   websites as videoWebsites,
   categoryOrder as videoOrder,
   categoryConfig as videoConfig,
@@ -43,6 +48,11 @@ import {
   categoryOrder as embeddedOrder,
   categoryConfig as embeddedConfig,
 } from '../data/websites.embedded';
+import {
+  websites as architectureWorkerWebsites,
+  categoryOrder as architectureWorkerOrder,
+  categoryConfig as architectureWorkerConfig,
+} from '../data/websites.architecture.worker';
 import {
 
   websites as marketingWebsites,
@@ -95,6 +105,11 @@ export default function CategoryStartPage({
       websites: defaultWebsites,
       categoryOrder: defaultOrder,
       categoryConfig: defaultConfig,
+    },
+    'architecture-worker': {
+      websites: architectureWorkerWebsites,
+      categoryOrder: architectureWorkerOrder,
+      categoryConfig: architectureWorkerConfig,
     },
     embedded: {
       websites: embeddedWebsites,
@@ -149,8 +164,17 @@ export default function CategoryStartPage({
     ...roleEntries,
   } as const;
 
+  const baseCategory =
+    categories.find(
+      (c) => categorySlug === c.slug || categorySlug.startsWith(`${c.slug}-`),
+    )?.slug;
+
   const fallback =
-    dataMap[categorySlug as keyof typeof dataMap] ?? dataMap.architecture;
+    dataMap[categorySlug as keyof typeof dataMap] ??
+    (baseCategory
+      ? dataMap[baseCategory as keyof typeof dataMap]
+      : undefined) ??
+    dataMap.architecture;
 
   const [websites, setWebsites] = useState<Website[]>(fallback.websites);
   const [loading, setLoading] = useState(!!jsonFile);

--- a/src/pages/MainLanding.tsx
+++ b/src/pages/MainLanding.tsx
@@ -74,7 +74,7 @@ export default function MainLanding() {
                     {insurancePersonaItems.map((it) => (
                       <Link
                         key={it.key}
-                        to={`/category/insurance/${it.key}`}
+                        to={`/category/insurance-${it.key}`}
                         className="px-2 py-1 hover:underline"
                       >
                         <span className="mr-1">{it.icon}</span>

--- a/src/pages/PersonaSelectPage.tsx
+++ b/src/pages/PersonaSelectPage.tsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+import { personaCategories } from "@/data/personas";
+
+interface Props {
+  slug: string;
+}
+
+export default function PersonaSelectPage({ slug }: Props) {
+  const category = personaCategories.find((c) => c.slug === slug);
+  if (!category) return <div className="p-6">잘못된 경로입니다.</div>;
+
+  return (
+    <div className="mx-auto max-w-6xl px-4">
+      <h1 className="text-center text-2xl font-bold my-6">
+        {category.title} 사용자 선택
+      </h1>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {category.items.map((it) => (
+          <Link
+            key={it.slug}
+            to={`/category/${slug}-${it.slug}`}
+            className="rounded-xl border p-5 hover:shadow text-center"
+          >
+            <div className="mt-2 font-semibold">{it.title}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add generic persona picker for categories with multiple personas
- handle hyphenated persona routes and insurance personas
- fall back to base category data when persona-specific data is missing

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c9ef53d0832e9483f0dc784e670c