### PR TITLE
Remove top favorites buttons from listings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,6 @@ import { websites, categoryConfig, categoryOrder } from "./data/websites";
 import { FavoritesData, CustomSite, Website } from "./types";
 import "./App.css";
 import { applyPreset } from "./utils/applyPreset";
-import { toggleFavorite as toggleFavoriteData } from "./utils/favorites";
 import { parseFavoritesData, parseCustomSites } from "./utils/validation";
 import { getStarterData } from "./utils/startPageStorage";
 import { Skeleton } from "./components/ui/skeleton";
@@ -276,18 +275,6 @@ export default function App() {
     return [...items, ...folderItems];
   };
 
-  const toggleFavorite = (websiteId: string) => {
-    try {
-      const newData = toggleFavoriteData(favoritesData, websiteId);
-      const isCurrentlyFavorited = getAllFavoriteIds().includes(websiteId);
-      setFavoritesData(newData);
-      toast.success(
-        isCurrentlyFavorited ? "즐겨찾기에서 제거되었습니다." : "즐겨찾기에 추가되었습니다."
-      );
-    } catch (e) {
-      toast.error("즐겨찾기 변경에 실패했습니다.");
-    }
-  };
 
   const handleAddFav = (id: string) => {
     try {
@@ -480,9 +467,6 @@ export default function App() {
                           sites={categorizedWebsites[category] || []}
                           config={categoryConfig[category]}
                           showDescriptions={showDescriptions}
-                          // ✅ (핵심) 즐겨찾기 상태 & 토글 연결
-                          favorites={getAllFavoriteIds()}
-                          onToggleFavorite={toggleFavorite}
                         />
                       ))}
                     </div>

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -7,8 +7,6 @@ interface CategoryCardProps {
   sites: Website[];
   config?: CategoryConfig;
   showDescriptions: boolean;
-  favorites: string[];
-  onToggleFavorite: (id: string) => void;
 }
 
 export function CategoryCard({
@@ -16,8 +14,6 @@ export function CategoryCard({
   sites,
   config,
   showDescriptions,
-  favorites,
-  onToggleFavorite,
 }: CategoryCardProps) {
   const safeSites = Array.isArray(sites) ? sites : [];
   const [visibleCount, setVisibleCount] = useState(6);
@@ -93,8 +89,6 @@ export function CategoryCard({
                   key={website.id}
                   website={website}
                   isDraggable={false}
-                  isFavorited={favorites.includes(website.id)}
-                  onToggleFavorite={onToggleFavorite}
                   showDescription={showDescriptions}
                 />
               ))}

--- a/src/components/CategoryPageLayout.tsx
+++ b/src/components/CategoryPageLayout.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { CategoryCard } from "@/components/CategoryCard";
-import type { FavoritesData, Website, CategoryConfigMap } from "@/types";
-import { loadFavoritesData, saveFavoritesData } from "@/utils/startPageStorage";
-import { toggleFavorite as toggleFavoriteData } from "@/utils/favorites";
+import type { Website, CategoryConfigMap } from "@/types";
 import { validateCategoryKeys } from "@/utils/validateCategories";
 
 interface CategoryPageLayoutProps {
   websites: Website[];
   categoryOrder: string[];
   categoryConfig: CategoryConfigMap;
-  storageNamespace: string;
   pageTitle: string;
   categoryTitle?: string;
   showDescriptions?: boolean;
@@ -20,23 +17,11 @@ export function CategoryPageLayout({
   websites,
   categoryOrder,
   categoryConfig,
-  storageNamespace,
   pageTitle,
   categoryTitle,
   showDescriptions = true,
   loading = false,
 }: CategoryPageLayoutProps) {
-  const [favoritesData, setFavoritesData] = useState<FavoritesData>(() =>
-    loadFavoritesData(storageNamespace),
-  );
-
-  useEffect(() => {
-    setFavoritesData(loadFavoritesData(storageNamespace));
-  }, [storageNamespace]);
-
-  useEffect(() => {
-    saveFavoritesData(favoritesData, storageNamespace);
-  }, [favoritesData, storageNamespace]);
 
   useEffect(() => {
     document.title = categoryTitle
@@ -60,11 +45,6 @@ export function CategoryPageLayout({
 
   if (loading) return <div className="p-6">로딩 중…</div>;
 
-  const toggleFavorite = (id: string) => {
-    setFavoritesData((prev) => toggleFavoriteData(prev, id));
-  };
-  const favoriteIds = favoritesData.items.map((i) => i.id);
-
   return (
     <div className="p-4">
       <div className="mx-auto max-w-[1180px]">
@@ -79,8 +59,6 @@ export function CategoryPageLayout({
               sites={categorizedWebsites[slug] || []}
               config={categoryConfig[slug]}
               showDescriptions={showDescriptions}
-              favorites={favoriteIds}
-              onToggleFavorite={toggleFavorite}
             />
           ))}
         </div>

--- a/src/components/StartPage.tsx
+++ b/src/components/StartPage.tsx
@@ -477,8 +477,6 @@ export function StartPage({
                         sites={categorizedWebsites[slug] || []}
                         config={categoryConfig[slug]}
                         showDescriptions={showDescriptions}
-                        favorites={favoritesData.items.map((i) => i.id)}
-                        onToggleFavorite={handleToggleFavorite}
                       />
                     );
                   })}

--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -5,32 +5,22 @@ import { SiteIcon } from "./SiteIcon";
 
 interface WebsiteItemProps {
   website: Website;
-  isFavorited: boolean;
   showDescription: boolean;
-  onToggleFavorite: (id: string) => void;
   isDraggable?: boolean;
-  onDragStart: (e: React.DragEvent, website: Website) => void;
+  onDragStart?: (e: React.DragEvent, website: Website) => void;
 }
 
 export function WebsiteItem({
   website,
-  isFavorited,
   showDescription,
-  onToggleFavorite,
   isDraggable = false,
   onDragStart,
 }: WebsiteItemProps) {
   if (!website?.url || !website?.title) return null;
 
-  const handleFavoriteClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    onToggleFavorite(website.id);
-  };
-
   const handleDragStart = (e: React.DragEvent) => {
     e.dataTransfer.setData("websiteId", website.id);
-    onDragStart(e, website);
+    onDragStart?.(e, website);
   };
 
   return (
@@ -40,36 +30,19 @@ export function WebsiteItem({
       draggable={isDraggable}
       onDragStart={handleDragStart}
     >
-      <div className="flex items-center justify-between gap-2 w-full">
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <SiteIcon website={website} size={16} className="w-4 h-4 rounded border shrink-0" />
-          <a
-            href={website.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block truncate text-[var(--main-dark)] focus:outline-none"
-            style={{ fontSize: "12.5px" }}
-            title={website.title}
-            onClick={() => trackVisit(website.id)}
-          >
-            {website.title}
-          </a>
-        </div>
-
-        <button
-          onClick={handleFavoriteClick}
-          aria-label="즐겨찾기"
-          className="favorite w-5 h-5 flex items-center justify-center bg-transparent border-0 cursor-pointer rounded transition-colors hover:bg-pink-100"
-          type="button"
+      <div className="flex items-center gap-2 w-full">
+        <SiteIcon website={website} size={16} className="w-4 h-4 rounded border shrink-0" />
+        <a
+          href={website.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block truncate text-[var(--main-dark)] focus:outline-none"
+          style={{ fontSize: "12.5px" }}
+          title={website.title}
+          onClick={() => trackVisit(website.id)}
         >
-          <svg
-            className={`w-3 h-3 urwebs-star-icon ${isFavorited ? "favorited" : ""}`}
-            viewBox="0 0 24 24"
-            strokeWidth="1"
-          >
-            <polygon points="12,2 15,8 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8" />
-          </svg>
-        </button>
+          {website.title}
+        </a>
       </div>
 
       {showDescription && (website.summary || website.description) && (

--- a/src/modules/insurance/PersonaPage.tsx
+++ b/src/modules/insurance/PersonaPage.tsx
@@ -43,7 +43,6 @@ export default function InsurancePersonaPage({ persona: personaProp }: Props = {
       .sort(sortSites);
   }, [bundle]);
 
-  const storageNamespace = `favorites:insurance-${persona}`;
   const categoryTitle = `보험 · ${personaLabels[persona] || persona}`;
 
   if (!bundle) return <div className="p-6">잘못된 경로입니다.</div>;
@@ -53,7 +52,6 @@ export default function InsurancePersonaPage({ persona: personaProp }: Props = {
       websites={websites}
       categoryOrder={["insurance"]}
       categoryConfig={{ insurance: { title: "보험" } }}
-      storageNamespace={storageNamespace}
       pageTitle="나의 시작페이지"
       categoryTitle={categoryTitle}
       showDescriptions={true}

--- a/src/pages/CategoryStartPage.tsx
+++ b/src/pages/CategoryStartPage.tsx
@@ -98,7 +98,6 @@ type Props = {
   categorySlug: string;
   title?: string;
   jsonFile?: string;
-  storageNamespace?: string;
   /** 부동산 역할별 페이지 등에서 카테고리 제목 커스터마이즈 */
   categoryTitleOverride?: string;
 };
@@ -107,7 +106,6 @@ export default function CategoryStartPage({
   categorySlug,
   title = '나의 시작페이지',
   jsonFile,
-  storageNamespace = `favorites:${categorySlug}`,
   categoryTitleOverride,
 }: Props) {
 
@@ -261,7 +259,6 @@ export default function CategoryStartPage({
       websites={websites}
       categoryOrder={fallback.categoryOrder}
       categoryConfig={fallback.categoryConfig}
-      storageNamespace={storageNamespace}
       pageTitle={title}
       categoryTitle={categoryTitle}
       loading={loading}


### PR DESCRIPTION
## Summary
- remove star/favorite buttons from website items
- simplify category components and pages to drop favorites props

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm run lint` *(fails: parserOptions.project missing)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d8c72b9c832eb3c1e6fb42e5d634