### PR TITLE
style: thicken border for favorite items

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5204,7 +5204,7 @@ html {
 
 .urwebs-favorite-item {
   background: var(--favorite-item-bg);
-  border: 1.5px solid var(--border-urwebs);
+  border: 2px solid var(--border-urwebs);
   cursor: move;
   border-radius: .5rem;
   transition: box-shadow .15s, border-color .15s;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -295,7 +295,7 @@ html {
 
 .urwebs-favorite-item {
   background: var(--favorite-item-bg);
-  border: 1.5px solid var(--border-urwebs);
+  border: 2px solid var(--border-urwebs);
   border-radius: 0.5rem;
   cursor: move;
   transition: box-shadow 0.15s, border-color 0.15s;


### PR DESCRIPTION
## Summary
- thicken favorites item borders for clearer emphasis

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run lint` *(fails: parserOptions.project must be provided)*
- `npm run typecheck` *(fails: many TS7026/TS7016 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c767dab450832e8d1eba8e78d7f5aa