### PR TITLE
Remove favorites UI from category pages

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Website, CategoryConfig } from "../types";
 import { WebsiteItem } from "./WebsiteItem";
 
@@ -7,8 +7,6 @@ interface CategoryCardProps {
   sites: Website[];
   config?: CategoryConfig;
   showDescriptions: boolean;
-  favorites: string[];
-  onToggleFavorite: (id: string) => void;
 }
 
 export function CategoryCard({
@@ -16,8 +14,6 @@ export function CategoryCard({
   sites,
   config,
   showDescriptions,
-  favorites,
-  onToggleFavorite,
 }: CategoryCardProps) {
   const safeSites = Array.isArray(sites) ? sites : [];
   const [visibleCount, setVisibleCount] = useState(6);
@@ -92,9 +88,6 @@ export function CategoryCard({
                 <WebsiteItem
                   key={website.id}
                   website={website}
-                  isDraggable={false}
-                  isFavorited={favorites.includes(website.id)}
-                  onToggleFavorite={onToggleFavorite}
                   showDescription={showDescriptions}
                 />
               ))}

--- a/src/components/CategoryPageLayout.tsx
+++ b/src/components/CategoryPageLayout.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { CategoryCard } from "@/components/CategoryCard";
-import type { FavoritesData, Website, CategoryConfigMap } from "@/types";
-import { loadFavoritesData, saveFavoritesData } from "@/utils/startPageStorage";
-import { toggleFavorite as toggleFavoriteData } from "@/utils/favorites";
+import type { Website, CategoryConfigMap } from "@/types";
 import { validateCategoryKeys } from "@/utils/validateCategories";
 
 interface CategoryPageLayoutProps {
@@ -20,23 +18,13 @@ export function CategoryPageLayout({
   websites,
   categoryOrder,
   categoryConfig,
-  storageNamespace,
+  storageNamespace: _storageNamespace,
   pageTitle,
   categoryTitle,
   showDescriptions = true,
   loading = false,
 }: CategoryPageLayoutProps) {
-  const [favoritesData, setFavoritesData] = useState<FavoritesData>(() =>
-    loadFavoritesData(storageNamespace),
-  );
-
-  useEffect(() => {
-    setFavoritesData(loadFavoritesData(storageNamespace));
-  }, [storageNamespace]);
-
-  useEffect(() => {
-    saveFavoritesData(favoritesData, storageNamespace);
-  }, [favoritesData, storageNamespace]);
+  void _storageNamespace;
 
   useEffect(() => {
     document.title = categoryTitle
@@ -60,11 +48,6 @@ export function CategoryPageLayout({
 
   if (loading) return <div className="p-6">로딩 중…</div>;
 
-  const toggleFavorite = (id: string) => {
-    setFavoritesData((prev) => toggleFavoriteData(prev, id));
-  };
-  const favoriteIds = favoritesData.items.map((i) => i.id);
-
   return (
     <div className="p-4">
       <div className="mx-auto max-w-[1180px]">
@@ -79,8 +62,6 @@ export function CategoryPageLayout({
               sites={categorizedWebsites[slug] || []}
               config={categoryConfig[slug]}
               showDescriptions={showDescriptions}
-              favorites={favoriteIds}
-              onToggleFavorite={toggleFavorite}
             />
           ))}
         </div>

--- a/src/components/WebsiteItem.tsx
+++ b/src/components/WebsiteItem.tsx
@@ -1,75 +1,37 @@
-import React from "react";
 import { Website } from "../types";
 import { trackVisit } from "../utils/visitTrack";
 import { SiteIcon } from "./SiteIcon";
 
 interface WebsiteItemProps {
   website: Website;
-  isFavorited: boolean;
   showDescription: boolean;
-  onToggleFavorite: (id: string) => void;
-  isDraggable?: boolean;
-  onDragStart: (e: React.DragEvent, website: Website) => void;
 }
 
-export function WebsiteItem({
-  website,
-  isFavorited,
-  showDescription,
-  onToggleFavorite,
-  isDraggable = false,
-  onDragStart,
-}: WebsiteItemProps) {
+export function WebsiteItem({ website, showDescription }: WebsiteItemProps) {
   if (!website?.url || !website?.title) return null;
-
-  const handleFavoriteClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    onToggleFavorite(website.id);
-  };
-
-  const handleDragStart = (e: React.DragEvent) => {
-    e.dataTransfer.setData("websiteId", website.id);
-    onDragStart(e, website);
-  };
 
   return (
     <li
       className="urwebs-website-item relative flex w-full flex-col items-start min-h-9 rounded-md min-w-0 hover:bg-gray-100 focus-within:ring-2 focus-within:ring-blue-400"
       style={{ height: showDescription ? "auto" : undefined }}
-      draggable={isDraggable}
-      onDragStart={handleDragStart}
     >
-      <div className="flex items-center justify-between gap-2 w-full">
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <SiteIcon website={website} size={16} className="w-4 h-4 rounded border shrink-0" />
-          <a
-            href={website.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block truncate text-[var(--main-dark)] focus:outline-none"
-            style={{ fontSize: "12.5px" }}
-            title={website.title}
-            onClick={() => trackVisit(website.id)}
-          >
-            {website.title}
-          </a>
-        </div>
-
-        <button
-          onClick={handleFavoriteClick}
-          aria-label="즐겨찾기"
-          className="favorite w-5 h-5 flex items-center justify-center bg-transparent border-0 cursor-pointer rounded transition-colors hover:bg-pink-100"
-          type="button"
+      <div className="flex items-center gap-2 min-w-0 w-full">
+        <SiteIcon
+          website={website}
+          size={16}
+          className="w-4 h-4 rounded border shrink-0"
+        />
+        <a
+          href={website.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block truncate text-[var(--main-dark)] focus:outline-none"
+          style={{ fontSize: "12.5px" }}
+          title={website.title}
+          onClick={() => trackVisit(website.id)}
         >
-          <svg
-            className={`w-3 h-3 urwebs-star-icon ${isFavorited ? "favorited" : ""}`}
-            viewBox="0 0 24 24"
-            strokeWidth="1"
-          >
-            <polygon points="12,2 15,8 22,9 17,14 18,21 12,18 6,21 7,14 2,9 9,8" />
-          </svg>
-        </button>
+          {website.title}
+        </a>
       </div>
 
       {showDescription && (website.summary || website.description) && (


### PR DESCRIPTION
## Summary
- remove favorites persistence and toggles from category layout and cards
- simplify website list items to only show titles and descriptions without favorite buttons

## Testing
- npm run lint *(fails: react-hooks/exhaustive-deps rule missing in config)*
- npm run typecheck *(fails: project lacks React type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68d536498af4832ea1f37d542ff739c0