### PR TITLE
Restructure starter packs into widget-based dashboard

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,86 +1,19 @@
 // src/Root.tsx
 import React from "react";
-import { Routes, Route, Navigate, useParams } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import { Toaster } from "sonner";
+import AppLandingPage from "@/app/page";
+import StarterPackRoute from "@/app/StarterPackRoute";
 import { AppErrorBoundary } from "./components/AppErrorBoundary";
-import BoardList from "./pages/BoardList";
-import PostDetail from "./pages/PostDetail";
-import PostWrite from "./pages/PostWrite";
-import MainLanding from "./pages/MainLanding";
-import CategoryStartPage from "./pages/CategoryStartPage";
-import PersonaOverview from "./pages/PersonaOverview";
-import InsurancePersonaPage from "@/modules/insurance/PersonaPage";
-import PersonaSelectPage from "./pages/PersonaSelectPage";
-import { personaCategories } from "@/data/personas";
-
-function RoutedCategoryPage() {
-  const { slug = "architecture" } = useParams<{ slug: string }>();
-
-  const personaCategory = personaCategories.find(
-    (p) => slug === p.slug || slug.startsWith(`${p.slug}-`),
-  );
-
-  if (personaCategory) {
-    const baseSlug = personaCategory.slug;
-    const persona = slug === baseSlug ? undefined : slug.slice(baseSlug.length + 1);
-
-    if (!persona && personaCategory.items.length > 1) {
-      return <PersonaSelectPage slug={baseSlug} />;
-    }
-
-    if (baseSlug === "insurance") {
-      return <InsurancePersonaPage persona={persona ?? ""} />;
-    }
-  }
-
-  return (
-    <CategoryStartPage
-      categorySlug={slug}
-      title="나의 시작페이지"
-      storageNamespace={`favorites:${slug}`}
-    />
-  );
-}
-
-function RedirectFieldsToCategory() {
-  const { slug } = useParams();
-  return <Navigate to={`/category/${slug ?? ""}`} replace />;
-}
 
 export default function Root() {
   return (
     <AppErrorBoundary>
       <>
         <Routes>
-          <Route path="/" element={<MainLanding />} />
-          {/* 구 라우트 호환: /fields/:slug -> /category/:slug */}
-          <Route path="/fields/:slug" element={<RedirectFieldsToCategory />} />
-          <Route path="/personas" element={<PersonaOverview />} />
-          <Route path="/category/:slug" element={<RoutedCategoryPage />} />
-          <Route
-            path="/architecture"
-            element={<Navigate to="/category/architecture" replace />}
-          />
-          <Route
-            path="/realestate"
-            element={<Navigate to="/category/realestate" replace />}
-          />
-          <Route
-            path="/stocks"
-            element={<Navigate to="/category/stocks" replace />}
-          />
-          <Route
-            path="/webdev"
-            element={<Navigate to="/category/webdev" replace />}
-          />
-          <Route
-            path="/start"
-            element={<Navigate to="/category/architecture" replace />}
-          />
-          <Route path="/notice" element={<BoardList board="notice" />} />
-          <Route path="/free" element={<BoardList board="free" />} />
-          <Route path="/post/:id" element={<PostDetail />} />
-          <Route path="/write" element={<PostWrite />} />
+          <Route path="/" element={<AppLandingPage />} />
+          <Route path="/app" element={<AppLandingPage />} />
+          <Route path="/app/:section/:topic" element={<StarterPackRoute />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
         <Toaster position="top-center" />

--- a/src/app/StarterPackRoute.tsx
+++ b/src/app/StarterPackRoute.tsx
@@ -1,0 +1,14 @@
+import { Navigate, useParams } from "react-router-dom";
+import StarterPackPage from "@/app/[section]/[topic]/page";
+
+export default function StarterPackRoute() {
+  const params = useParams<{ section: string; topic: string }>();
+  const section = params.section ?? "";
+  const topic = params.topic ?? "";
+
+  if (!section || !topic) {
+    return <Navigate to="/app" replace />;
+  }
+
+  return <StarterPackPage sectionSlug={section} topicSlug={topic} />;
+}

--- a/src/app/[section]/[topic]/page.tsx
+++ b/src/app/[section]/[topic]/page.tsx
@@ -1,0 +1,32 @@
+import { DashboardLayout } from "@/components/dashboard/DashboardLayout";
+import { WidgetGrid } from "@/components/dashboard/WidgetGrid";
+import { WidgetRenderer } from "@/components/dashboard/WidgetRenderer";
+import { findSection, findTopic } from "@/data/starterpacks";
+
+interface StarterPackPageProps {
+  sectionSlug: string;
+  topicSlug: string;
+}
+
+export default function StarterPackPage({ sectionSlug, topicSlug }: StarterPackPageProps) {
+  const section = findSection(sectionSlug);
+  const topic = findTopic(sectionSlug, topicSlug);
+
+  if (!section || !topic) {
+    return (
+      <DashboardLayout title="스타터팩을 찾을 수 없습니다">
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white p-10 text-center text-sm text-slate-500">
+          선택한 섹션 또는 토픽이 존재하지 않습니다.
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout title={`${section.title} · ${topic.title}`} description={topic.description}>
+      <WidgetGrid>
+        <WidgetRenderer section={section} topic={topic} widgets={topic.widgets} />
+      </WidgetGrid>
+    </DashboardLayout>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,36 @@
+import { Link } from "react-router-dom";
+import { starterPackSections } from "@/data/starterpacks";
+
+export default function AppLandingPage() {
+  return (
+    <div className="mx-auto max-w-5xl space-y-10 px-4 py-16">
+      <header className="space-y-3 text-center">
+        <p className="text-sm font-medium text-blue-500">URwebs 스타터팩</p>
+        <h1 className="text-3xl font-bold text-slate-800">관심사에 맞는 대시보드를 바로 시작하세요</h1>
+        <p className="text-sm text-slate-500">
+          업무, 취미, 학습, 자기계발, 일상까지. 원하는 토픽을 선택하면 필요한 위젯이 자동으로 준비됩니다.
+        </p>
+      </header>
+      <section className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {starterPackSections.map((section) => (
+          <article key={section.slug} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-xl font-semibold text-slate-800">{section.title}</h2>
+            <p className="mt-2 text-sm text-slate-500">{section.description}</p>
+            <div className="mt-4 space-y-2">
+              {section.topics.map((topic) => (
+                <Link
+                  key={topic.slug}
+                  to={`/app/${section.slug}/${topic.slug}`}
+                  className="flex items-center justify-between rounded-lg border border-slate-100 px-3 py-2 text-sm text-slate-600 hover:border-blue-200 hover:bg-blue-50"
+                >
+                  <span>{topic.title}</span>
+                  <span className="text-xs text-blue-500">바로가기 →</span>
+                </Link>
+              ))}
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from "react";
+
+interface DashboardLayoutProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+export function DashboardLayout({ title, description, actions, children }: DashboardLayoutProps) {
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-10">
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800">{title}</h1>
+          {description && <p className="text-sm text-slate-500">{description}</p>}
+        </div>
+        {actions}
+      </header>
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/src/components/dashboard/WidgetGrid.tsx
+++ b/src/components/dashboard/WidgetGrid.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+
+interface WidgetGridProps {
+  children: ReactNode;
+}
+
+export function WidgetGrid({ children }: WidgetGridProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {children}
+    </div>
+  );
+}

--- a/src/components/dashboard/WidgetRenderer.tsx
+++ b/src/components/dashboard/WidgetRenderer.tsx
@@ -1,0 +1,25 @@
+import { renderWidget } from "@/lib/registry";
+import {
+  StarterPackSection,
+  StarterPackTopic,
+  WidgetInstance,
+  WidgetRenderContext,
+} from "@/types/widgets";
+
+interface WidgetRendererProps {
+  section: StarterPackSection;
+  topic: StarterPackTopic;
+  widgets: WidgetInstance[];
+}
+
+export function WidgetRenderer({ section, topic, widgets }: WidgetRendererProps) {
+  const context: WidgetRenderContext = { section, topic };
+
+  return (
+    <>
+      {widgets.map((widget) => (
+        <div key={widget.id}>{renderWidget(widget, context)}</div>
+      ))}
+    </>
+  );
+}

--- a/src/components/widgets/CalendarWidgetV2.tsx
+++ b/src/components/widgets/CalendarWidgetV2.tsx
@@ -1,0 +1,78 @@
+import { WidgetComponentProps } from "@/types/widgets";
+
+type CalendarWidgetConfig = {
+  highlightDates?: string[];
+};
+
+const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+
+function normalizeDateKey(date: Date) {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function buildCalendar(date: Date) {
+  const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+  const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+  const leading = firstDay.getDay();
+  const trailing = 6 - lastDay.getDay();
+
+  const days: (Date | null)[] = [];
+  for (let i = 0; i < leading; i += 1) days.push(null);
+  for (let d = 1; d <= lastDay.getDate(); d += 1) {
+    days.push(new Date(date.getFullYear(), date.getMonth(), d));
+  }
+  for (let i = 0; i < trailing; i += 1) days.push(null);
+  return days;
+}
+
+export function CalendarWidgetV2({ id, title, config }: WidgetComponentProps<CalendarWidgetConfig>) {
+  const today = new Date();
+  const dates = buildCalendar(today);
+  const highlight = new Set(
+    (config.highlightDates ?? []).map((value) => normalizeDateKey(new Date(value))),
+  );
+
+  const titleLabel = today.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+  });
+
+  return (
+    <section
+      aria-labelledby={`${id}-title`}
+      className="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <div className="mb-4 flex items-baseline justify-between">
+        <h3 id={`${id}-title`} className="text-sm font-semibold text-slate-700">
+          {title ?? "캘린더"}
+        </h3>
+        <time className="text-xs text-slate-400" dateTime={today.toISOString()}>
+          {titleLabel}
+        </time>
+      </div>
+      <div className="grid flex-1 grid-cols-7 gap-1 text-center text-xs">
+        {weekdays.map((weekday) => (
+          <span key={weekday} className="font-medium text-slate-400">
+            {weekday}
+          </span>
+        ))}
+        {dates.map((date, index) => (
+          <span
+            key={index}
+            className={`flex h-8 items-center justify-center rounded-full text-sm ${
+              date
+                ? highlight.has(normalizeDateKey(date))
+                  ? "bg-blue-100 font-semibold text-blue-600"
+                  : "text-slate-600"
+                : "text-transparent"
+            }`}
+          >
+            {date ? date.getDate() : ""}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/widgets/ChecklistWidget.tsx
+++ b/src/components/widgets/ChecklistWidget.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useState } from "react";
+import { WidgetComponentProps } from "@/types/widgets";
+
+type ChecklistItem = {
+  id: string;
+  label: string;
+  checked?: boolean;
+};
+
+type ChecklistWidgetConfig = {
+  storageKey?: string;
+  items: ChecklistItem[];
+};
+
+function usePersistentChecklist(id: string, config: ChecklistWidgetConfig) {
+  const storageKey = useMemo(
+    () => `starterpack:checklist:${config.storageKey ?? id}`,
+    [config.storageKey, id],
+  );
+  const [items, setItems] = useState<ChecklistItem[]>(config.items);
+
+  useEffect(() => {
+    const raw = window.localStorage.getItem(storageKey);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as ChecklistItem[];
+        setItems(parsed);
+      } catch (error) {
+        console.warn("Failed to parse checklist state", error);
+      }
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    window.localStorage.setItem(storageKey, JSON.stringify(items));
+  }, [items, storageKey]);
+
+  return { items, setItems };
+}
+
+export function ChecklistWidget({ id, title, config }: WidgetComponentProps<ChecklistWidgetConfig>) {
+  const { items, setItems } = usePersistentChecklist(id, config);
+
+  const toggleItem = (itemId: string) => {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === itemId ? { ...item, checked: !item.checked } : item,
+      ),
+    );
+  };
+
+  return (
+    <section className="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-slate-700">{title ?? "체크리스트"}</h3>
+        <span className="text-xs text-slate-400">
+          완료 {items.filter((item) => item.checked).length}/{items.length}
+        </span>
+      </div>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.id}>
+            <label className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1 hover:bg-slate-50">
+              <input
+                type="checkbox"
+                checked={Boolean(item.checked)}
+                onChange={() => toggleItem(item.id)}
+                className="h-3.5 w-3.5"
+              />
+              <span className="text-sm text-slate-600">{item.label}</span>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/widgets/LinksWidget.tsx
+++ b/src/components/widgets/LinksWidget.tsx
@@ -1,0 +1,44 @@
+import { WidgetComponentProps } from "@/types/widgets";
+
+type LinkItem = {
+  title: string;
+  url: string;
+  description?: string;
+};
+
+type LinksWidgetConfig = {
+  links: LinkItem[];
+};
+
+export function LinksWidget({ id, title, config }: WidgetComponentProps<LinksWidgetConfig>) {
+  return (
+    <section
+      aria-labelledby={`${id}-title`}
+      className="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <h3 id={`${id}-title`} className="text-sm font-semibold text-slate-700">
+          {title ?? "추천 링크"}
+        </h3>
+        <span className="text-xs text-slate-400">{config.links.length}개</span>
+      </div>
+      <ul className="flex-1 space-y-2 overflow-y-auto">
+        {config.links.map((link) => (
+          <li key={link.url}>
+            <a
+              href={link.url}
+              target="_blank"
+              rel="noreferrer"
+              className="block rounded-lg border border-slate-100 px-3 py-2 transition hover:border-blue-200 hover:bg-blue-50"
+            >
+              <p className="text-sm font-medium text-slate-800">{link.title}</p>
+              {link.description && (
+                <p className="text-xs text-slate-500">{link.description}</p>
+              )}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/widgets/MapWidget.tsx
+++ b/src/components/widgets/MapWidget.tsx
@@ -1,0 +1,30 @@
+import { WidgetComponentProps } from "@/types/widgets";
+
+type MapWidgetConfig = {
+  query: string;
+};
+
+export function MapWidget({ id, title, config }: WidgetComponentProps<MapWidgetConfig>) {
+  return (
+    <section className="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-slate-700">{title ?? "지도"}</h3>
+        <span className="text-xs text-slate-400">네이버 지도</span>
+      </div>
+      <iframe
+        key={id}
+        title={title ?? "지도"}
+        className="h-64 flex-1 rounded-lg border border-slate-100"
+        src={`https://map.naver.com/v5/search/${encodeURIComponent(config.query)}`}
+      />
+      <a
+        className="mt-2 inline-flex text-xs text-blue-500 hover:underline"
+        href={`https://map.naver.com/v5/search/${encodeURIComponent(config.query)}`}
+        target="_blank"
+        rel="noreferrer"
+      >
+        큰 지도에서 보기 ↗
+      </a>
+    </section>
+  );
+}

--- a/src/components/widgets/MusicWidget.tsx
+++ b/src/components/widgets/MusicWidget.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { fetchSpotifyPlaylist } from "@/lib/sources/spotify";
+import { WidgetComponentProps } from "@/types/widgets";
+import { MusicItem } from "@/types/sources";
+
+type MusicWidgetConfig = {
+  query: string;
+};
+
+export function MusicWidget({ id, title, config }: WidgetComponentProps<MusicWidgetConfig>) {
+  const [tracks, setTracks] = useState<MusicItem[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      const result = await fetchSpotifyPlaylist(config.query);
+      if (mounted) {
+        setTracks(result);
+      }
+    };
+
+    void load();
+
+    return () => {
+      mounted = false;
+    };
+  }, [config.query]);
+
+  return (
+    <section className="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-slate-700">{title ?? "배경 음악"}</h3>
+        <span className="text-xs text-slate-400">Spotify</span>
+      </div>
+      <ul className="space-y-3">
+        {tracks.map((track) => (
+          <li key={`${id}-${track.id}`} className="rounded-lg border border-slate-100 p-3">
+            <p className="text-sm font-medium text-slate-700">{track.title}</p>
+            {track.artist && <p className="text-xs text-slate-500">{track.artist}</p>}
+            <a
+              className="mt-1 inline-flex text-xs text-green-600 hover:underline"
+              href={track.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Spotify에서 듣기 ↗
+            </a>
+          </li>
+        ))}
+        {!tracks.length && (
+          <li className="rounded-lg border border-dashed border-slate-200 p-3 text-center text-sm text-slate-400">
+            추천 곡을 찾을 수 없습니다.
+          </li>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/widgets/VideosWidget.tsx
+++ b/src/components/widgets/VideosWidget.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { fetchYoutubePlaylist } from "@/lib/sources/youtube";
+import { WidgetComponentProps } from "@/types/widgets";
+import { VideoItem } from "@/types/sources";
+
+type VideosWidgetConfig = {
+  query: string;
+};
+
+export function VideosWidget({ id, title, config }: WidgetComponentProps<VideosWidgetConfig>) {
+  const [videos, setVideos] = useState<VideoItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      setIsLoading(true);
+      const result = await fetchYoutubePlaylist(config.query);
+      if (mounted) {
+        setVideos(result);
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+
+    return () => {
+      mounted = false;
+    };
+  }, [config.query]);
+
+  return (
+    <section className="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-slate-700">{title ?? "추천 영상"}</h3>
+        {isLoading && <span className="text-xs text-slate-400">불러오는 중...</span>}
+      </div>
+      <ul className="flex-1 space-y-3 overflow-y-auto">
+        {videos.map((video) => (
+          <li key={`${id}-${video.id}`} className="rounded-lg border border-slate-100 p-3">
+            <p className="text-sm font-medium text-slate-700">{video.title}</p>
+            <a
+              className="mt-1 inline-flex text-xs text-blue-500 hover:underline"
+              href={video.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              YouTube에서 열기 ↗
+            </a>
+          </li>
+        ))}
+        {!videos.length && !isLoading && (
+          <li className="rounded-lg border border-dashed border-slate-200 p-3 text-center text-sm text-slate-400">
+            추천 영상을 찾을 수 없습니다.
+          </li>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/widgets/WeatherWidgetV2.tsx
+++ b/src/components/widgets/WeatherWidgetV2.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { fetchWeatherSummary } from "@/lib/sources/weather";
+import { WidgetComponentProps } from "@/types/widgets";
+
+type WeatherWidgetConfig = {
+  city?: string;
+};
+
+export function WeatherWidgetV2({ id, title, config }: WidgetComponentProps<WeatherWidgetConfig>) {
+  const [city, setCity] = useState(config.city ?? "서울");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [temperature, setTemperature] = useState<number | null>(null);
+  const [condition, setCondition] = useState<string>("");
+  const [icon, setIcon] = useState<string>("");
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const summary = await fetchWeatherSummary(city);
+        if (mounted) {
+          setTemperature(summary.temperature);
+          setCondition(summary.condition);
+          setIcon(summary.icon);
+          setError(null);
+        }
+      } catch (err) {
+        if (mounted) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      mounted = false;
+    };
+  }, [city]);
+
+  return (
+    <section className="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-slate-700">{title ?? "오늘의 날씨"}</h3>
+        <select
+          aria-label="도시 선택"
+          className="rounded border border-slate-200 bg-white px-2 py-1 text-xs"
+          value={city}
+          onChange={(event) => setCity(event.target.value)}
+        >
+          {[
+            "서울",
+            "부산",
+            "대구",
+            "인천",
+            "광주",
+            "대전",
+            "울산",
+            "제주",
+          ].map((option) => (
+            <option key={`${id}-${option}`} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex flex-1 flex-col items-center justify-center gap-1">
+        {isLoading && <p className="text-xs text-slate-400">데이터 불러오는 중...</p>}
+        {error && <p className="text-xs text-red-500">{error}</p>}
+        {!isLoading && !error && temperature !== null && (
+          <>
+            <span className="text-4xl">{icon}</span>
+            <p className="text-2xl font-semibold text-slate-700">{temperature}°C</p>
+            <p className="text-sm text-slate-500">{city} · {condition}</p>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/data/starterpacks/index.ts
+++ b/src/data/starterpacks/index.ts
@@ -1,0 +1,384 @@
+import { StarterPackSection } from "@/types/widgets";
+
+export const starterPackSections: StarterPackSection[] = [
+  {
+    slug: "work",
+    title: "업무",
+    description: "업무 효율을 높이는 실전 도구 모음",
+    topics: [
+      {
+        slug: "product-manager",
+        title: "프로덕트 매니저",
+        description: "하루 업무를 체계적으로 관리하는 PM 전용 스타터팩",
+        widgets: [
+          {
+            id: "pm-links",
+            kind: "links",
+            title: "협업 툴 바로가기",
+            props: {
+              links: [
+                {
+                  title: "Jira",
+                  url: "https://jira.atlassian.com",
+                  description: "이슈 및 스프린트 관리",
+                },
+                {
+                  title: "Notion",
+                  url: "https://www.notion.so",
+                  description: "회의록과 문서 정리",
+                },
+                {
+                  title: "Figma",
+                  url: "https://www.figma.com",
+                  description: "디자인 스펙 확인",
+                },
+              ],
+            },
+          },
+          {
+            id: "pm-checklist",
+            kind: "checklist",
+            props: {
+              storageKey: "pm-daily",
+              items: [
+                { id: "1", label: "데일리 스탠드업 준비" },
+                { id: "2", label: "이슈 업데이트 확인" },
+                { id: "3", label: "팀 공지 작성" },
+              ],
+            },
+          },
+          {
+            id: "pm-calendar",
+            kind: "calendar",
+            props: {
+              highlightDates: [],
+            },
+          },
+          {
+            id: "pm-music",
+            kind: "music",
+            props: {
+              query: "focus",
+            },
+          },
+        ],
+      },
+      {
+        slug: "remote-work",
+        title: "원격 근무",
+        description: "분산팀을 위한 협업 툴 모음",
+        widgets: [
+          {
+            id: "remote-links",
+            kind: "links",
+            props: {
+              links: [
+                {
+                  title: "Slack",
+                  url: "https://slack.com",
+                  description: "팀 커뮤니케이션",
+                },
+                {
+                  title: "Zoom",
+                  url: "https://zoom.us",
+                  description: "화상회의",
+                },
+                {
+                  title: "Linear",
+                  url: "https://linear.app",
+                  description: "이슈 트래킹",
+                },
+              ],
+            },
+          },
+          {
+            id: "remote-weather",
+            kind: "weather",
+            props: {
+              city: "서울",
+            },
+          },
+          {
+            id: "remote-videos",
+            kind: "videos",
+            props: {
+              query: "remote work",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: "hobby",
+    title: "취미",
+    description: "주말 취미 생활을 위한 큐레이션",
+    topics: [
+      {
+        slug: "camping",
+        title: "캠핑 스타터팩",
+        description: "초보 캠퍼를 위한 준비물과 정보",
+        widgets: [
+          {
+            id: "camping-checklist",
+            kind: "checklist",
+            props: {
+              storageKey: "camping",
+              items: [
+                { id: "tent", label: "텐트" },
+                { id: "chair", label: "캠핑 의자" },
+                { id: "lamp", label: "랜턴" },
+              ],
+            },
+          },
+          {
+            id: "camping-map",
+            kind: "map",
+            props: {
+              query: "캠핑장",
+            },
+          },
+          {
+            id: "camping-videos",
+            kind: "videos",
+            props: {
+              query: "캠핑",
+            },
+          },
+        ],
+      },
+      {
+        slug: "photography",
+        title: "사진 촬영",
+        description: "촬영 계획과 영감을 한 번에",
+        widgets: [
+          {
+            id: "photo-links",
+            kind: "links",
+            props: {
+              links: [
+                {
+                  title: "500px",
+                  url: "https://500px.com",
+                  description: "사진 영감",
+                },
+                {
+                  title: "Lightroom Presets",
+                  url: "https://www.adobe.com/kr/products/photoshop-lightroom.html",
+                  description: "프리셋 관리",
+                },
+              ],
+            },
+          },
+          {
+            id: "photo-calendar",
+            kind: "calendar",
+            props: {},
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: "study",
+    title: "학습",
+    description: "학습 루틴을 잡아주는 학습 스타터팩",
+    topics: [
+      {
+        slug: "investment",
+        title: "투자 공부",
+        description: "퇴근 후 투자 공부를 위한 루틴",
+        widgets: [
+          {
+            id: "invest-links",
+            kind: "links",
+            props: {
+              links: [
+                {
+                  title: "Investopedia",
+                  url: "https://www.investopedia.com",
+                },
+                {
+                  title: "네이버 증권",
+                  url: "https://finance.naver.com",
+                },
+              ],
+            },
+          },
+          {
+            id: "invest-checklist",
+            kind: "checklist",
+            props: {
+              items: [
+                { id: "news", label: "오늘의 시장 뉴스 체크" },
+                { id: "note", label: "학습 노트 작성" },
+              ],
+            },
+          },
+          {
+            id: "invest-videos",
+            kind: "videos",
+            props: {
+              query: "투자",
+            },
+          },
+        ],
+      },
+      {
+        slug: "architecture",
+        title: "건축사 자격증",
+        description: "건축사 시험 준비를 위한 계획",
+        widgets: [
+          {
+            id: "arch-links",
+            kind: "links",
+            props: {
+              links: [
+                { title: "대한건축사협회", url: "https://www.kira.or.kr" },
+                { title: "국가평생교육진흥원", url: "https://www.cb.or.kr" },
+              ],
+            },
+          },
+          {
+            id: "arch-calendar",
+            kind: "calendar",
+            props: {
+              highlightDates: ["2024-09-21"],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: "growth",
+    title: "자기계발",
+    description: "꾸준히 성장하는 나를 위한 루틴",
+    topics: [
+      {
+        slug: "reading",
+        title: "독서 루틴",
+        description: "매일 30분 독서를 위한 위젯",
+        widgets: [
+          {
+            id: "reading-checklist",
+            kind: "checklist",
+            props: {
+              items: [
+                { id: "select", label: "읽을 책 선정" },
+                { id: "note", label: "독서 노트 작성" },
+                { id: "share", label: "동료와 인사이트 공유" },
+              ],
+            },
+          },
+          {
+            id: "reading-music",
+            kind: "music",
+            props: {
+              query: "reading",
+            },
+          },
+        ],
+      },
+      {
+        slug: "mindfulness",
+        title: "마인드풀니스",
+        description: "명상과 감정 기록을 위한 루틴",
+        widgets: [
+          {
+            id: "mindfulness-links",
+            kind: "links",
+            props: {
+              links: [
+                { title: "Insight Timer", url: "https://insighttimer.com" },
+                { title: "Headspace", url: "https://www.headspace.com" },
+              ],
+            },
+          },
+          {
+            id: "mindfulness-calendar",
+            kind: "calendar",
+            props: {},
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: "daily",
+    title: "일상",
+    description: "매일을 더 편하게 만들어주는 일상 스타터팩",
+    topics: [
+      {
+        slug: "family",
+        title: "가족 일정",
+        description: "가족과 공유하는 일정 및 준비물",
+        widgets: [
+          {
+            id: "family-calendar",
+            kind: "calendar",
+            props: {},
+          },
+          {
+            id: "family-checklist",
+            kind: "checklist",
+            props: {
+              items: [
+                { id: "lunch", label: "도시락 준비" },
+                { id: "homework", label: "아이 숙제 확인" },
+              ],
+            },
+          },
+          {
+            id: "family-weather",
+            kind: "weather",
+            props: {
+              city: "인천",
+            },
+          },
+        ],
+      },
+      {
+        slug: "personal",
+        title: "나의 하루",
+        description: "개인 루틴과 영감을 한 곳에서",
+        widgets: [
+          {
+            id: "personal-links",
+            kind: "links",
+            props: {
+              links: [
+                { title: "네이버 메일", url: "https://mail.naver.com" },
+                { title: "구글 캘린더", url: "https://calendar.google.com" },
+              ],
+            },
+          },
+          {
+            id: "personal-music",
+            kind: "music",
+            props: {
+              query: "chill",
+            },
+          },
+          {
+            id: "personal-map",
+            kind: "map",
+            props: {
+              query: "카페",
+            },
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export function findSection(sectionSlug: string) {
+  return starterPackSections.find((section) => section.slug === sectionSlug);
+}
+
+export function findTopic(sectionSlug: string, topicSlug: string) {
+  const section = findSection(sectionSlug);
+  if (!section) return undefined;
+  return section.topics.find((topic) => topic.slug === topicSlug);
+}

--- a/src/lib/registry.tsx
+++ b/src/lib/registry.tsx
@@ -1,0 +1,62 @@
+import { CalendarWidgetV2 } from "@/components/widgets/CalendarWidgetV2";
+import { ChecklistWidget } from "@/components/widgets/ChecklistWidget";
+import { LinksWidget } from "@/components/widgets/LinksWidget";
+import { MapWidget } from "@/components/widgets/MapWidget";
+import { MusicWidget } from "@/components/widgets/MusicWidget";
+import { VideosWidget } from "@/components/widgets/VideosWidget";
+import { WeatherWidgetV2 } from "@/components/widgets/WeatherWidgetV2";
+import {
+  WidgetComponent,
+  WidgetComponentProps,
+  WidgetInstance,
+  WidgetKind,
+  WidgetRenderContext,
+} from "@/types/widgets";
+
+type RegistryEntry = {
+  component: WidgetComponent<Record<string, unknown>>;
+  defaultTitle?: string;
+};
+
+const registry: Record<WidgetKind, RegistryEntry> = {
+  links: { component: LinksWidget, defaultTitle: "추천 링크" },
+  weather: { component: WeatherWidgetV2, defaultTitle: "오늘의 날씨" },
+  checklist: { component: ChecklistWidget, defaultTitle: "체크리스트" },
+  calendar: { component: CalendarWidgetV2, defaultTitle: "캘린더" },
+  videos: { component: VideosWidget, defaultTitle: "추천 영상" },
+  music: { component: MusicWidget, defaultTitle: "배경 음악" },
+  map: { component: MapWidget, defaultTitle: "지도" },
+};
+
+export function registerWidget(kind: WidgetKind, entry: RegistryEntry) {
+  registry[kind] = entry;
+}
+
+export function getWidgetEntry(kind: WidgetKind): RegistryEntry | undefined {
+  return registry[kind];
+}
+
+export function createWidgetProps(
+  instance: WidgetInstance,
+  context: WidgetRenderContext,
+): WidgetComponentProps<Record<string, unknown>> {
+  const entry = getWidgetEntry(instance.kind);
+  if (!entry) {
+    throw new Error(`Widget kind '${instance.kind}' is not registered`);
+  }
+
+  return {
+    id: instance.id,
+    title: instance.title ?? entry.defaultTitle,
+    config: (instance.props ?? {}) as Record<string, unknown>,
+    context,
+  };
+}
+
+export function renderWidget(instance: WidgetInstance, context: WidgetRenderContext) {
+  const entry = getWidgetEntry(instance.kind);
+  if (!entry) return null;
+  const props = createWidgetProps(instance, context);
+  const Widget = entry.component as WidgetComponent<Record<string, unknown>>;
+  return <Widget {...props} />;
+}

--- a/src/lib/sources/spotify.ts
+++ b/src/lib/sources/spotify.ts
@@ -1,0 +1,20 @@
+import { MusicItem } from "@/types/sources";
+
+const mockTracks: MusicItem[] = [
+  {
+    id: "focus-1",
+    title: "Deep Work Beats",
+    artist: "Flow State",
+    url: "https://open.spotify.com/track/focus-1",
+  },
+  {
+    id: "camp-1",
+    title: "Campfire Vibes",
+    artist: "Outdoor Sessions",
+    url: "https://open.spotify.com/track/camp-1",
+  },
+];
+
+export async function fetchSpotifyPlaylist(query: string): Promise<MusicItem[]> {
+  return mockTracks.filter((track) => track.title.includes(query));
+}

--- a/src/lib/sources/weather.ts
+++ b/src/lib/sources/weather.ts
@@ -1,0 +1,10 @@
+import { WeatherSummary } from "@/types/sources";
+
+export async function fetchWeatherSummary(city: string): Promise<WeatherSummary> {
+  return {
+    location: city,
+    temperature: 23,
+    condition: "맑음",
+    icon: "☀️",
+  };
+}

--- a/src/lib/sources/youtube.ts
+++ b/src/lib/sources/youtube.ts
@@ -1,0 +1,23 @@
+import { VideoItem } from "@/types/sources";
+
+const mockVideos: VideoItem[] = [
+  {
+    id: "1",
+    title: "프로덕트 매니저를 위한 우선순위 설정",
+    url: "https://www.youtube.com/watch?v=example1",
+  },
+  {
+    id: "2",
+    title: "캠핑 장비 초보자 가이드",
+    url: "https://www.youtube.com/watch?v=example2",
+  },
+  {
+    id: "3",
+    title: "퇴근 후 투자 공부 루틴",
+    url: "https://www.youtube.com/watch?v=example3",
+  },
+];
+
+export async function fetchYoutubePlaylist(query: string): Promise<VideoItem[]> {
+  return mockVideos.filter((video) => video.title.includes(query));
+}

--- a/src/lib/storage/cloud.ts
+++ b/src/lib/storage/cloud.ts
@@ -1,0 +1,19 @@
+import { StorageAdapter } from "@/types/storage";
+
+type MemoryStore = Record<string, unknown>;
+const memoryStore: MemoryStore = {};
+
+export const cloudStorageAdapter: StorageAdapter = {
+  async get<T>(key: string) {
+    return (memoryStore[key] as T | undefined) ?? null;
+  },
+  async set<T>(key: string, value: T) {
+    memoryStore[key] = value;
+  },
+  async remove(key: string) {
+    delete memoryStore[key];
+  },
+  async sync(key: string, value: unknown) {
+    memoryStore[key] = value;
+  },
+};

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,0 +1,9 @@
+import { cloudStorageAdapter } from "./cloud";
+import { localStorageAdapter } from "./local";
+import { StorageAdapter } from "@/types/storage";
+
+export function createStorageAdapter(isAuthenticated: boolean): StorageAdapter {
+  return isAuthenticated ? cloudStorageAdapter : localStorageAdapter;
+}
+
+export { localStorageAdapter, cloudStorageAdapter };

--- a/src/lib/storage/local.ts
+++ b/src/lib/storage/local.ts
@@ -1,0 +1,25 @@
+import { StorageAdapter } from "@/types/storage";
+
+const isBrowser = typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+export const localStorageAdapter: StorageAdapter = {
+  async get<T>(key: string) {
+    if (!isBrowser) return null;
+    const value = window.localStorage.getItem(key);
+    if (!value) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch (error) {
+      console.warn("Failed to parse local storage value", key, error);
+      return null;
+    }
+  },
+  async set<T>(key: string, value: T) {
+    if (!isBrowser) return;
+    window.localStorage.setItem(key, JSON.stringify(value));
+  },
+  async remove(key: string) {
+    if (!isBrowser) return;
+    window.localStorage.removeItem(key);
+  },
+};

--- a/src/types/sources.ts
+++ b/src/types/sources.ts
@@ -1,0 +1,21 @@
+export interface VideoItem {
+  id: string;
+  title: string;
+  url: string;
+  thumbnail?: string;
+}
+
+export interface MusicItem {
+  id: string;
+  title: string;
+  artist?: string;
+  url: string;
+  thumbnail?: string;
+}
+
+export interface WeatherSummary {
+  location: string;
+  temperature: number;
+  condition: string;
+  icon: string;
+}

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,0 +1,13 @@
+import { StarterPackTopic } from "./widgets";
+
+export interface StarterPackState {
+  topic: StarterPackTopic;
+  widgetState: Record<string, unknown>;
+}
+
+export interface StorageAdapter {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T): Promise<void>;
+  remove(key: string): Promise<void>;
+  sync?(key: string, value: unknown): Promise<void>;
+}

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -1,0 +1,59 @@
+import { JSX, ReactNode } from "react";
+
+export type WidgetKind =
+  | "links"
+  | "weather"
+  | "checklist"
+  | "calendar"
+  | "videos"
+  | "music"
+  | "map";
+
+export interface WidgetLayout {
+  w: number;
+  h: number;
+  x?: number;
+  y?: number;
+}
+
+export interface WidgetInstance<TKind extends WidgetKind = WidgetKind> {
+  id: string;
+  kind: TKind;
+  title?: string;
+  description?: string;
+  props?: Record<string, unknown>;
+  layout?: WidgetLayout;
+}
+
+export interface StarterPackTopic {
+  slug: string;
+  title: string;
+  description?: string;
+  widgets: WidgetInstance[];
+}
+
+export interface StarterPackSection {
+  slug: string;
+  title: string;
+  description?: string;
+  topics: StarterPackTopic[];
+  icon?: ReactNode;
+}
+
+export interface WidgetRenderContext {
+  section: StarterPackSection;
+  topic: StarterPackTopic;
+}
+
+export interface WidgetComponentProps<
+  TConfig extends Record<string, unknown> = Record<string, unknown>,
+> {
+  id: string;
+  title?: string;
+  config: TConfig;
+  context: WidgetRenderContext;
+}
+
+export type WidgetComponent<TConfig extends Record<string, unknown>> = (
+  props: WidgetComponentProps<TConfig>,
+) => JSX.Element | null;


### PR DESCRIPTION
## Summary
- add a new /app router powered by starter pack section/topic data
- implement a widget registry, layout primitives, and reusable widget components
- scaffold storage adapters and external source stubs to support widget state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8d6d50c28832e983f809858db6bc2